### PR TITLE
ci(release): fail the version bump when a deferred removal is overdue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,6 +491,17 @@ jobs:
       - name: Verify version sync across policed manifests (REL-07, PR-time)
         run: python3 scripts/check-version-sync.py
 
+      # `WalBatchConfig` was promised "at the next major"; v6.0.0 shipped two
+      # days later without it, because the constraint lived in a doc comment and
+      # nothing reads a doc comment when a version is bumped. This runs beside
+      # the version guard on purpose: the release commit that raises the major
+      # is the one that must go red.
+      - name: Deferred removals are not overdue
+        run: python3 scripts/check-deferred-removals.py
+
+      - name: Test the deferred-removal guard
+        run: python3 -m unittest scripts.tests.test_check_deferred_removals
+
       - name: Test feature-claims audit script
         run: python3 -m unittest scripts.tests.test_check_feature_claims
 

--- a/scripts/check-deferred-removals.py
+++ b/scripts/check-deferred-removals.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Fail the build when a removal deferred to a major version has been skipped.
+
+# Why this exists
+
+`WalBatchConfig` was to be removed "at the next major". The next major shipped
+two days after that was written — `v6.0.0`, 2026-09-02 — and did not remove it.
+Nothing was broken and nobody was careless: the constraint lived in a doc
+comment and in an issue (#2174), and neither is read by the thing that bumps a
+version.
+
+A deferred removal is a promise with a due date. This is the alarm clock. When
+the workspace major reaches the version a removal was promised for, every site
+listed below must be gone, or CI refuses the release that bumped it.
+
+# Why it fails the bump rather than warning before it
+
+Warning "the next major is near" needs someone to be listening at the right
+moment, which is the failure mode that produced this file. Failing *on* the bump
+needs nobody: the release commit that raises the major cannot go green until the
+removal lands. The check is only as good as its list, and the list is short on
+purpose — an entry is added when a removal is deliberately postponed, which is
+rare and always a decision someone wrote down.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: Removals promised for a future major, and every site that must be gone.
+#:
+#: A removal that leaves one site behind is not done, which is why sites are
+#: listed individually rather than as a single symbol: `WalBatchConfig` also has
+#: a field, an `ENGINE_SECTIONS` entry and an `ENV_SECTIONS` entry, and #2174
+#: records that the last of those was missed by the issue text itself.
+DEFERRED_REMOVALS: "list[dict]" = [
+    {
+        "what": "WalBatchConfig and its [wal_batch] config table",
+        "remove_at_major": 7,
+        "issue": 2174,
+        "sites": [
+            ("crates/velesdb-core/src/config.rs", "pub struct WalBatchConfig"),
+            ("crates/velesdb-core/src/config.rs", "pub wal_batch:"),
+            ("crates/velesdb-core/src/config.rs", '"wal_batch"'),
+            # The compiler catches the Rust sites; it says nothing about a guide
+            # that keeps documenting a table users can no longer set.
+            ("docs/guides/CONFIGURATION.md", "wal_batch"),
+            ("docs/CORE_WIRING_DEBT.md", "wal_batch"),
+        ],
+        # `docs/guides/MIGRATION_v6.0.0.md` is deliberately NOT a site. It
+        # records that the table stayed in 6.0.0, which remains true after 7.0.0
+        # removes it — a historical note is not stale merely because history
+        # moved on, and forcing its deletion would falsify the record.
+    },
+]
+
+#: Anchored inside `[workspace.package]`, and matching any version string
+#: rather than a strict triple.
+#:
+#: Both details are borrowed from `check-version-sync.py`, which already carries
+#: the scar: an unanchored search reads the FIRST line-initial `version =` in the
+#: file, which a long-form `[workspace.dependencies.x]` table above the package
+#: section would win. And `"7.0.0-rc.1"` is a version this repository ships —
+#: `create-release-tag.sh` accepts a prerelease suffix — so a pattern demanding
+#: a closing quote after the patch number would refuse to read a real manifest
+#: and report it as a missing version.
+_PACKAGE_SECTION = "[workspace.package]"
+_VERSION_LINE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def workspace_major(root: Path) -> int:
+    """The major version `[workspace.package]` declares.
+
+    Raises `RuntimeError` rather than guessing: a guard that cannot read the
+    version it gates on must say so, not pass.
+    """
+    manifest = root / "Cargo.toml"
+    try:
+        text = manifest.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"cannot read {manifest}: {exc}") from exc
+    section_at = text.find(_PACKAGE_SECTION)
+    if section_at == -1:
+        raise RuntimeError(f"no {_PACKAGE_SECTION} section in {manifest}")
+    match = _VERSION_LINE.search(text, section_at)
+    if match is None:
+        raise RuntimeError(f"no version under {_PACKAGE_SECTION} in {manifest}")
+    major, _, _ = match.group(1).partition(".")
+    try:
+        return int(major)
+    except ValueError as exc:
+        raise RuntimeError(f"unreadable major in version {match.group(1)!r}") from exc
+
+
+def validate_entry(entry: "dict") -> None:
+    """Refuses a malformed entry with `RuntimeError`, never a bare `TypeError`.
+
+    The module promises that an unreadable tree answers 2 and never 1. An entry
+    missing a key or carrying a string where an int belongs would raise out of
+    `run` uncaught, and Python exits 1 on an uncaught exception — a refusal this
+    guard never made, wearing the exit code of one it did.
+    """
+    for key in ("what", "remove_at_major", "issue", "sites"):
+        if key not in entry:
+            raise RuntimeError(f"deferred-removal entry is missing {key!r}: {entry}")
+    if not isinstance(entry["remove_at_major"], int):
+        raise RuntimeError(
+            f"remove_at_major must be an int, got {entry['remove_at_major']!r}"
+        )
+    if not entry["sites"]:
+        raise RuntimeError(
+            f"deferred-removal entry {entry['what']!r} lists no sites, so it "
+            "would pass the day its major arrives while the code is untouched"
+        )
+
+
+def surviving_sites(root: Path, entry: "dict") -> "list[str]":
+    """Sites from `entry` that are still present in the tree."""
+    survivors = []
+    for relative, needle in entry["sites"]:
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            # The file itself is gone, so the site is too.
+            continue
+        except OSError as exc:
+            raise RuntimeError(f"cannot read {path}: {exc}") from exc
+        if needle in text:
+            survivors.append(f"{relative}: {needle}")
+    return survivors
+
+
+def run(root: Path) -> int:
+    major = workspace_major(root)
+    overdue = []
+    for entry in DEFERRED_REMOVALS:
+        validate_entry(entry)
+        if major < entry["remove_at_major"]:
+            continue
+        survivors = surviving_sites(root, entry)
+        if survivors:
+            overdue.append((entry, survivors))
+
+    if not overdue:
+        pending = [e for e in DEFERRED_REMOVALS if major < e["remove_at_major"]]
+        print(
+            f"PASSED: workspace major is {major}; "
+            f"{len(pending)} deferred removal(s) not yet due, none overdue."
+        )
+        return 0
+
+    print(
+        f"FAILED: workspace major is {major} and "
+        f"{len(overdue)} deferred removal(s) are overdue:",
+        file=sys.stderr,
+    )
+    for entry, survivors in overdue:
+        print(
+            f"  - {entry['what']} was promised for {entry['remove_at_major']}.0.0 "
+            f"(#{entry['issue']}), and these sites are still here:",
+            file=sys.stderr,
+        )
+        for site in survivors:
+            print(f"      {site}", file=sys.stderr)
+    print(
+        "\nRemove them, or move the entry's `remove_at_major` and say in the issue "
+        "why the promise slipped. Editing this list silently is the failure this "
+        "guard exists to stop.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", default=str(REPO_ROOT), help="repository root to scan")
+    args = parser.parse_args(argv)
+    # A tree this guard cannot read answers 2, never 1: a refusal it never made
+    # must not look like a refusal.
+    try:
+        return run(Path(args.root).resolve())
+    except (OSError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1,1319 +1,1364 @@
 {
- "_purpose": [
-  "The declared set of repository guards. Before this file existed, the set was",
-  "implicit in the YAML text of .github/workflows/ and in GitHub's branch",
-  "protection settings, and the two were never confronted: removing a guard's",
-  "`run:` line from ci.yml turned nothing red (issue #1702), and a guard that",
-  "runs in a workflow nobody requires is decorative at merge time (#1698).",
-  "",
-  "scripts/tests/test_ci_gate_reachability.py confronts this file with the",
-  "workflows AND with the filesystem. The filesystem half is what makes the",
-  "registry impossible to shrink silently: every guard-shaped script under",
-  "scripts/ must appear here, either under `guards` or under `unwired` with a",
-  "written reason. Deleting an entry does not remove the obligation — the script",
-  "is still on disk, so the suite demands an accounting for it."
- ],
- "_schema": {
-  "script": "repo-relative path and identity of the executable guard — or the workflow itself for a legacy inline guard (see `inline_steps`)",
-  "inline_steps": "legacy support when a guard is written as steps inside `workflow` rather than as a script under scripts/: the exact `- name:` of each step that must exist in `job`. The wiring test reads those steps instead of hunting for a script invocation. #1715 extracted the last such guards, but the parser and mutation contracts remain so a future inline guard cannot be invisible.",
-  "workflow": "the workflow file whose job invokes it",
-  "job": "the job key inside that workflow",
-  "required": "true when a failure of `job` must fail the single required check (CI Success)",
-  "mode": "strict = a finding fails the build; warn = it does not (see exit_condition)",
-  "exit_condition": "mandatory when mode is warn: what has to happen for it to become strict",
-  "self_test": "unittest module that proves the guard refuses; null when none exists",
-  "self_test_required": "true when that module runs inside a required job",
-  "blind_spot": "known limit of the guard's reach, with the issue tracking it",
-  "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required",
-  "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the repaired state. `argv` may itself be keyed by those two states when arguments are the policy input. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
-  "base": "optional `repository` inside a vector: copy every tracked path from the current checkout before applying the state overlay. This is the scalable accepted control for a guard whose shipped registry structurally requires many real surfaces; the vector records only its deliberate drift instead of duplicating the tree.",
-  "replace": "optional exact text replacements keyed by `files` and `accepts`, applied after the base and file overlay. Each `old` string must occur exactly once, so a stale mutation is an error rather than a vacuous green vector.",
-  "executable": "optional fixture paths keyed by `files` and `accepts` that receive executable bits. This lets process gates receive deterministic tool doubles while exercising their real sequencing and exit propagation.",
-  "refusal_untested": "mandatory when a strict, required guard declares no `must_refuse`: why no vector exists yet, and the issue tracking it. A guard nobody has seen refuse is the defect of this campaign; this field keeps that visible instead of absent.",
-  "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make. Optional state-keyed `author` (`Name <email>`), `message`, and `relation` are also part of the state. `relation` is `ancestor` or `diverged` and creates refs/heads/vector-base so freshness policy can receive both histories.",
-  "subguards": "for a guard exposing a `--guard <name>` selector: every selector that must actually be invoked in `job`. Without it, a script cited once for another selector satisfies the wiring test, and a sub-guard can be dropped from CI while the registry keeps announcing it — measured, that disarm stayed green.",
-  "not_a_gate": "scripts a workflow runs that CANNOT refuse — no non-zero exit path. Surfaced by the reverse sweep (workflows -> registry) and kept out of `guards` so the registry never overstates what it covers. The `reason` is mandatory and the no-failure-path claim is verified against the source."
- },
- "_json_not_yaml": [
-  "gate-contracts.yml runs these suites with a bare actions/setup-python and",
-  "installs nothing, so importing PyYAML here would be an ImportError in CI — a",
-  "guard that cannot run. json is stdlib everywhere. Same reasoning that keeps",
-  "the workflow parsers in test_ci_gate_reachability.py regex-based."
- ],
- "guards": [
-  {
-   "script": "scripts/check_prod_unwraps.py",
-   "purpose": "No .unwrap()/.expect() in production code (QUALITY_BAR Gate 3).",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_prod_unwraps",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "None known. #1700 is closed: a #[cfg(test)] gate now skips ITS item by following braces instead of stopping the file, and block-comment tracking runs first so a marker quoted in /* */ no longer blinds it. Measured after the fix: the 33 914 formerly unread lines contain zero production unwrap/expect."
-   },
-   "must_refuse": [
-    {
-     "vector": "a production unwrap AFTER a #[cfg(test)] module — the 33 914-line blindness of #1700",
-     "files": {
-      "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\npub fn prod() { y.unwrap(); }\n"
-     },
-     "accepts": {
-      "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\npub fn prod() { y.unwrap_or_default(); }\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "a marker merely QUOTED in a /* */ comment must not blind the file",
-     "files": {
-      "crates/velesdb-core/src/lib.rs": "/*\n * #[cfg(test)]\n */\npub fn prod() { y.unwrap(); }\n"
-     },
-     "accepts": {
-      "crates/velesdb-core/src/lib.rs": "/*\n * #[cfg(test)]\n */\npub fn prod() { y.unwrap_or_default(); }\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
+  "_purpose": [
+    "The declared set of repository guards. Before this file existed, the set was",
+    "implicit in the YAML text of .github/workflows/ and in GitHub's branch",
+    "protection settings, and the two were never confronted: removing a guard's",
+    "`run:` line from ci.yml turned nothing red (issue #1702), and a guard that",
+    "runs in a workflow nobody requires is decorative at merge time (#1698).",
+    "",
+    "scripts/tests/test_ci_gate_reachability.py confronts this file with the",
+    "workflows AND with the filesystem. The filesystem half is what makes the",
+    "registry impossible to shrink silently: every guard-shaped script under",
+    "scripts/ must appear here, either under `guards` or under `unwired` with a",
+    "written reason. Deleting an entry does not remove the obligation — the script",
+    "is still on disk, so the suite demands an accounting for it."
+  ],
+  "_schema": {
+    "script": "repo-relative path and identity of the executable guard — or the workflow itself for a legacy inline guard (see `inline_steps`)",
+    "inline_steps": "legacy support when a guard is written as steps inside `workflow` rather than as a script under scripts/: the exact `- name:` of each step that must exist in `job`. The wiring test reads those steps instead of hunting for a script invocation. #1715 extracted the last such guards, but the parser and mutation contracts remain so a future inline guard cannot be invisible.",
+    "workflow": "the workflow file whose job invokes it",
+    "job": "the job key inside that workflow",
+    "required": "true when a failure of `job` must fail the single required check (CI Success)",
+    "mode": "strict = a finding fails the build; warn = it does not (see exit_condition)",
+    "exit_condition": "mandatory when mode is warn: what has to happen for it to become strict",
+    "self_test": "unittest module that proves the guard refuses; null when none exists",
+    "self_test_required": "true when that module runs inside a required job",
+    "blind_spot": "known limit of the guard's reach, with the issue tracking it",
+    "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required",
+    "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the repaired state. `argv` may itself be keyed by those two states when arguments are the policy input. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
+    "base": "optional `repository` inside a vector: copy every tracked path from the current checkout before applying the state overlay. This is the scalable accepted control for a guard whose shipped registry structurally requires many real surfaces; the vector records only its deliberate drift instead of duplicating the tree.",
+    "replace": "optional exact text replacements keyed by `files` and `accepts`, applied after the base and file overlay. Each `old` string must occur exactly once, so a stale mutation is an error rather than a vacuous green vector.",
+    "executable": "optional fixture paths keyed by `files` and `accepts` that receive executable bits. This lets process gates receive deterministic tool doubles while exercising their real sequencing and exit propagation.",
+    "refusal_untested": "mandatory when a strict, required guard declares no `must_refuse`: why no vector exists yet, and the issue tracking it. A guard nobody has seen refuse is the defect of this campaign; this field keeps that visible instead of absent.",
+    "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make. Optional state-keyed `author` (`Name <email>`), `message`, and `relation` are also part of the state. `relation` is `ancestor` or `diverged` and creates refs/heads/vector-base so freshness policy can receive both histories.",
+    "subguards": "for a guard exposing a `--guard <name>` selector: every selector that must actually be invoked in `job`. Without it, a script cited once for another selector satisfies the wiring test, and a sub-guard can be dropped from CI while the registry keeps announcing it — measured, that disarm stayed green.",
+    "not_a_gate": "scripts a workflow runs that CANNOT refuse — no non-zero exit path. Surfaced by the reverse sweep (workflows -> registry) and kept out of `guards` so the registry never overstates what it covers. The `reason` is mandatory and the no-failure-path claim is verified against the source."
   },
-  {
-   "script": "scripts/check-inline-tests.py",
-   "purpose": "Freeze the inline-test-module debt: no new inline #[cfg(test)] mod {...} block, and no growth of an existing one, against a frozen baseline.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_inline_tests",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Line-based brace/bracket counting inherits check_prod_unwraps.py's known caveat: a multi-line string literal containing an unmatched brace or bracket can unbalance the count. Likewise line-based: a #[cfg(...)] attribute wrapped across several lines is not recognized as a gate (none exist in the tree today; rustfmt keeps cfg attributes on one line at current lengths)."
-   },
-   "must_refuse": [
+  "_json_not_yaml": [
+    "gate-contracts.yml runs these suites with a bare actions/setup-python and",
+    "installs nothing, so importing PyYAML here would be an ImportError in CI — a",
+    "guard that cannot run. json is stdlib everywhere. Same reasoning that keeps",
+    "the workflow parsers in test_ci_gate_reachability.py regex-based."
+  ],
+  "guards": [
     {
-     "vector": "a new inline test module in a file the frozen baseline has never seen",
-     "files": {
-      "crates/velesdb-core/src/lib.rs": "pub fn a() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n"
-     },
-     "accepts": {
-      "crates/velesdb-core/src/lib.rs": "pub fn a() {}\n\n#[cfg(test)]\n#[path = \"lib_tests.rs\"]\nmod lib_tests;\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "a baselined inline test module that grew past its frozen line count",
-     "files": {
-      "scripts/inline-tests-baseline.txt": "crates/velesdb-core/src/lib.rs\t4\n",
-      "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn a() {}\n    fn b() {}\n}\n"
-     },
-     "accepts": {
-      "scripts/inline-tests-baseline.txt": "crates/velesdb-core/src/lib.rs\t4\n",
-      "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-file-budgets.py",
-   "purpose": "Freeze the count of over-budget (>1000-line) production Rust files: no file newly crosses the budget, no over-budget file grows, against a frozen baseline.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_file_budgets",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Raw line counts only: a file can stay under 1000 lines while its complexity grows (lizard's CCN gate polices that axis), and generated files are budgeted like hand-written ones - none exist under crates/*/src today."
-   },
-   "must_refuse": [
-    {
-     "vector": "a production file that newly crosses the 1000-line budget",
-     "files": {
-      "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\npub fn f999() {}\npub fn f1000() {}\n"
-     },
-     "accepts": {
-      "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "a baselined over-budget file that grew past its frozen line count",
-     "files": {
-      "scripts/file-budgets-baseline.txt": "crates/velesdb-core/src/lib.rs\t1001\n",
-      "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\npub fn f999() {}\npub fn f1000() {}\npub fn f1001() {}\n"
-     },
-     "accepts": {
-      "scripts/file-budgets-baseline.txt": "crates/velesdb-core/src/lib.rs\t1001\n",
-      "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\npub fn f999() {}\npub fn f1000() {}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-trait-forwarding.py",
-   "purpose": "Every adapter that exists only to delegate forwards its trait WHOLE: the generic wrapper `impl<T: Trait + ?Sized> Trait for Box<T>|Arc<T>|Rc<T>`, and the erased alias `impl Trait for DynTrait` where `type DynTrait = Box<dyn Trait>` (the shape a binding holds). rustc already refuses an impl missing a *required* method, so a partial forwarding can only drop a method with a default body — which compiles and silently runs the default instead of the concrete override (the #1690-#1692 gap family). A plain `impl Trait for Backend` is deliberately exempt: a concrete backend is entitled to the default. velesdb-memory's doctrine (src/lib.rs) states the rule; this guard is what makes it hold without a reviewer noticing.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_trait_forwarding",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Presence, not delegation: a forwarded method whose body ignores `(**self)` and reimplements the default satisfies the guard — only review catches that. Three further limits, each currently vacuous under crates/*/src: a `#[cfg]`-gated trait method is demanded unconditionally; an impl or alias produced by a macro is invisible to the text scan; and a trait defined outside the scanned tree is reported SKIPPED rather than checked, so a forwarding of a foreign trait is announced as unverified instead of passing quietly."
-   },
-   "must_refuse": [
-    {
-     "vector": "a wrapper forwarding that drops the trait's defaulted method — the #1692 shape rustc cannot catch",
-     "files": {
-      "crates/velesdb-memory/src/extract.rs": "pub struct Doc;\npub struct Graph;\n\n/// Reproduces the #1692 shape: a defaulted method next to a required one.\npub trait Extractor: Send + Sync {\n    fn extract(&self, input: &str) -> Doc;\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        let _ = input;\n        Graph\n    }\n}\n\nimpl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {\n    fn extract(&self, input: &str) -> Doc {\n        (**self).extract(input)\n    }\n}\n"
-     },
-     "accepts": {
-      "crates/velesdb-memory/src/extract.rs": "pub struct Doc;\npub struct Graph;\n\n/// Reproduces the #1692 shape: a defaulted method next to a required one.\npub trait Extractor: Send + Sync {\n    fn extract(&self, input: &str) -> Doc;\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        let _ = input;\n        Graph\n    }\n}\n\nimpl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {\n    fn extract(&self, input: &str) -> Doc {\n        (**self).extract(input)\n    }\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        (**self).extract_graph(input)\n    }\n}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "a partial forwarding whose trait is declared in a different file, so the miss is invisible at the impl site",
-     "files": {
-      "crates/velesdb-memory/src/context/estimator.rs": "pub trait TokenEstimator: Send + Sync {\n    fn estimate(&self, text: &str) -> usize;\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        4.0\n    }\n}\n",
-      "crates/velesdb-memory/src/context/boxed.rs": "use super::estimator::TokenEstimator;\n\nimpl<T: TokenEstimator + ?Sized> TokenEstimator for Box<T> {\n    fn estimate(&self, text: &str) -> usize {\n        (**self).estimate(text)\n    }\n}\n"
-     },
-     "accepts": {
-      "crates/velesdb-memory/src/context/estimator.rs": "pub trait TokenEstimator: Send + Sync {\n    fn estimate(&self, text: &str) -> usize;\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        4.0\n    }\n}\n",
-      "crates/velesdb-memory/src/context/boxed.rs": "use super::estimator::TokenEstimator;\n\nimpl<T: TokenEstimator + ?Sized> TokenEstimator for Box<T> {\n    fn estimate(&self, text: &str) -> usize {\n        (**self).estimate(text)\n    }\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        (**self).bytes_per_token_hint()\n    }\n}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "a partial forwarding on an erased `Dyn*` alias — the shape a binding holds, and the one with no generic parameter to pattern-match on",
-     "files": {
-      "crates/velesdb-memory/src/rerank.rs": "pub trait Reranker {\n    fn rerank(&self, query: &str) -> u8;\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        queries.len() as u8\n    }\n}\n\n/// The shape a binding holds: no generic parameter, so the wrapper pattern\n/// alone never sees this impl.\npub type DynReranker = Box<dyn Reranker + Send + Sync>;\n\nimpl Reranker for DynReranker {\n    fn rerank(&self, query: &str) -> u8 {\n        (**self).rerank(query)\n    }\n}\n"
-     },
-     "accepts": {
-      "crates/velesdb-memory/src/rerank.rs": "pub trait Reranker {\n    fn rerank(&self, query: &str) -> u8;\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        queries.len() as u8\n    }\n}\n\n/// The shape a binding holds: no generic parameter, so the wrapper pattern\n/// alone never sees this impl.\npub type DynReranker = Box<dyn Reranker + Send + Sync>;\n\nimpl Reranker for DynReranker {\n    fn rerank(&self, query: &str) -> u8 {\n        (**self).rerank(query)\n    }\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        (**self).rerank_batch(queries)\n    }\n}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/verify_unsafe_safety_template.py",
-   "purpose": "Every unsafe block carries a // SAFETY: comment (Gate 4).",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": null,
-   "self_test_required": false,
-   "must_refuse": [
-    {
-     "vector": "an unsafe block with no SAFETY comment in front of it",
-     "files": {
-      "src/lib.rs": "pub fn write(target: *mut u8) {\n    unsafe {\n        *target = 1;\n    }\n}\n"
-     },
-     "accepts": {
-      "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // - `target` is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases `target` for the duration of this call\n    // Reason: the caller owns the allocation and cannot express that in the type.\n    unsafe {\n        *target = 1;\n    }\n}\n"
-     },
-     "argv": [
-      "--files",
-      "{root}/src/lib.rs"
-     ]
-    },
-    {
-     "vector": "a second SAFETY header restating the one above it, with no condition bullet between them",
-     "files": {
-      "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // SAFETY: writing through the caller's pointer is sound.\n    // - target is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases target for the duration of this call\n    // Reason: the caller owns the allocation and cannot express that in the type.\n    unsafe {\n        *target = 1;\n    }\n}\n"
-     },
-     "accepts": {
-      "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // - target is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases target for the duration of this call\n    // SAFETY: writing through the caller's pointer is sound.\n    unsafe {\n        *target = 1;\n    }\n}\n"
-     },
-     "argv": [
-      "--files",
-      "{root}/src/lib.rs"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "Runs only on production .rs files changed by the PR, so it never re-reads unsafe blocks that predate it. Until the `lint` job checked out full history, that diff resolved to nothing at all and the gate read no files on any pull request; test_ci_gate_reachability now pins the fetch-depth."
-   }
-  },
-  {
-   "script": "scripts/check-todo-annotations.py",
-   "purpose": "TODO/FIXME/HACK follow the // TODO(EPIC-XXX): governance format.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": null,
-   "self_test_required": false,
-   "must_refuse": [
-    {
-     "vector": "a TODO carrying no EPIC/US tag and no issue number",
-     "files": {
-      "src/lib.rs": "// TODO: rewrite this once the index lands\npub fn f() {}\n"
-     },
-     "accepts": {
-      "src/lib.rs": "// TODO(EPIC-042): rewrite this once the index lands\npub fn f() {}\n"
-     },
-     "argv": [
-      "--files",
-      "{root}/src/lib.rs"
-     ]
-    },
-    {
-     "vector": "a FIXME carrying no tag — the verb changes, the obligation does not",
-     "files": {
-      "src/lib.rs": "// FIXME: the cast overflows above 2^53\npub fn f() {}\n"
-     },
-     "accepts": {
-      "src/lib.rs": "// FIXME(#1468): the cast overflows above 2^53\npub fn f() {}\n"
-     },
-     "argv": [
-      "--files",
-      "{root}/src/lib.rs"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "Diff-scoped to changed velesdb-core production files, like the unsafe guard \u2014 and it shared the same shallow-checkout blind spot, now pinned by test_ci_gate_reachability."
-   }
-  },
-  {
-   "script": "scripts/check-version-sync.py",
-   "purpose": "Version equality across policed manifests (REL-07), at PR time.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_version_sync",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "None known. Its self-test is reached by gate-contracts.yml's `unittest discover`, which the fold made required through the `gate-contracts` caller job."
-   },
-   "must_refuse": [
-    {
-     "vector": "a manifest stamped 9.9.9 against a 1.0.0 workspace — the drift this guard exists for",
-     "files": {
-      "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n\n[workspace.dependencies]\nvelesdb-core = { path = \"crates/velesdb-core\", version = \"1.0.0\" }\n",
-      "crates/velesdb-memory/Cargo.toml": "version = \"1.0.0\"\n",
-      "crates/velesdb-python/pyproject.toml": "[project]\nversion = \"9.9.9\"\n"
-     },
-     "accepts": {
-      "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n\n[workspace.dependencies]\nvelesdb-core = { path = \"crates/velesdb-core\", version = \"1.0.0\" }\n",
-      "crates/velesdb-memory/Cargo.toml": "version = \"1.0.0\"\n",
-      "crates/velesdb-python/pyproject.toml": "[project]\nversion = \"1.0.0\"\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-feature-claims.py",
-   "purpose": "Documented feature claims match real exports.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_feature_claims",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Breaks (reports column_store MISSING) if any string literal in velesdb-python/src uses a backslash line-continuation."
-   },
-   "must_refuse": [
-    {
-     "vector": "a roadmap entry still marked in-progress, which the audit must not let a README present as shipped",
-     "files": {
-      "ROADMAP.md": "## EPIC-010 Agent Memory SDK — in progress\n"
-     },
-     "accepts": {
-      "ROADMAP.md": "## EPIC-010 Agent Memory SDK — delivered\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-perf-claims.py",
-   "purpose": "Performance numbers stay consistent across documents.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_perf_claims",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Can reach exit 1 again (#1701 closed): the grouping key no longer contains its own value, so two documents claiming different numbers for one benchmark collide and are compared. Measured limit, not a defect: this repository's corpus yields ZERO comparable groups, so a green run here says nothing about the guard — which is exactly why its refusal is proven below on a corpus of its own. The Criterion front stays out of the exit code by design."
-   },
-   "must_refuse": [
-    {
-     "vector": "two documents claiming 38.6 us and 120.0 us for the same benchmark",
-     "files": {
-      "README.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 38.6 µs |\n",
-      "docs/BENCHMARKS.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 120.0 µs |\n"
-     },
-     "accepts": {
-      "README.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 38.6 µs |\n",
-      "docs/BENCHMARKS.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 39.0 µs |\n"
-     },
-     "argv": [
-      "--no-criterion",
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-mcp-doc-contract.py",
-   "purpose": "Documented MCP return shapes match the published outputSchema.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "mcp-doc-contract",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_mcp_doc_contract",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "the shipped MCP registry with feedback's documented confidence key renamed, against the untouched tracked repository",
-     "base": "repository",
-     "files": {},
-     "accepts": {},
-     "replace": {
-      "files": [
-       {
-        "path": "docs/reference/MCP_TOOLS.md",
-        "old": "Returns `{ id, id_str, confidence }`",
-        "new": "Returns `{ id, id_str, certainty }`"
-       }
-      ],
-      "accepts": []
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "batch 2: compile_context loses one published root field on the editable source skill",
-     "base": "repository",
-     "files": {},
-     "accepts": {},
-     "replace": {
-      "files": [
-       {
-        "path": "skills/velesdb-context-optimizer/SKILL.md",
-        "old": "`compile_context` returns `{content, sections, decisions, sources,\nretrieval_handles, insights, risk, warnings}`.",
-        "new": "`compile_context` returns `{content, sections, decisions, sources,\nretrieval_handles, insights, risk}`."
-       }
-      ],
-      "accepts": []
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "batch 3: remember_extracted renames a field in its durable background-job receipt",
-     "base": "repository",
-     "files": {},
-     "accepts": {},
-     "replace": {
-      "files": [
-       {
-        "path": "crates/velesdb-memory/skill/velesdb-memory/SKILL.md",
-        "old": "returns `{request_id, state, reused}` before model generation.",
-        "new": "returns `{request_id, state, accepted}` before model generation."
-       }
-      ],
-      "accepts": []
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ],
-   "subguards": [
-    "return-shape"
-   ]
-  },
-  {
-   "script": "scripts/check-skill-private-references.py",
-   "purpose": "No versioned skill points at something only the private repository holds.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "mcp-doc-contract",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_skill_private_references",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "a versioned skill sending the reader to a standard held in the closed repository",
-     "files": {
-      "skills/demo/SKILL.md": "# Demo\n\nBefore declaring premium coverage done, cross-check the axes.\n"
-     },
-     "accepts": {
-      "skills/demo/SKILL.md": "# Demo\n\nBefore declaring coverage done, cross-check the axes.\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "the bundled npm copy naming the private repository — that copy is the one that leaves the machine",
-     "files": {
-      "crates/velesdb-node/skills/demo/SKILL.md": "# Demo\n\nSee velesdb-private for the enforcing policy.\n"
-     },
-     "accepts": {
-      "crates/velesdb-node/skills/demo/SKILL.md": "# Demo\n\nSee the architecture reference for the boundary.\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "a tree holding no versioned skill at all — deleting skills/ is the cheapest way to retire this guard while leaving it in the workflow",
-     "files": {
-      "docs/README.md": "nothing to scan here\n"
-     },
-     "accepts": {
-      "docs/README.md": "nothing to scan here\n",
-      "skills/demo/SKILL.md": "# Demo\n\nUse recall before proposing an approach.\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "Reads the two declared markers and nothing else. It does NOT catch a bare issue or pull-request number belonging to the closed repository: the learning-loop skill arrived citing one three times, and no property of the text separates it from the public `#1455` and `#1473` two other skills cite usefully — a guess would either block those or catch nothing. That half was closed by rewriting the passages, not by this guard. Scope is the skill directories only, by design: docs/CORE_PREMIUM_SPLIT.md documents the split on purpose."
-   }
-  },
-  {
-   "script": "scripts/check-doc-contract.sh",
-   "purpose": "Every runtime route of the server is documented in the root README.",
-   "workflow": ".github/workflows/doc-contract.yml",
-   "job": "contract",
-   "required": true,
-   "mode": "strict",
-   "self_test": null,
-   "self_test_required": false,
-   "blind_spot": {
-    "issue": null,
-    "summary": "None known. #1707 is closed: the four routes (/collections/{name}/compact, points/raw, stream/enable, vacuum) are now documented in README.md, and DOC_CONTRACT_MODE's default flipped to strict in the same commit, so a full-sweep finding fails the build like the pinned routes always did."
-   },
-   "must_refuse": [
-    {
-     "vector": "a route added under the server crate without a matching README backtick entry — the four-route gap of #1707",
-     "files": {
-      "crates/velesdb-server/src/routes.rs": "pub fn build_router() {\n    Router::new()\n        .route(\"/query/explain\", post(explain))\n        .route(\"/aggregate\", post(aggregate))\n        .route(\"/collections/{name}/vacuum\", post(vacuum_collection));\n}\n",
-      "README.md": "# Test fixture\n\nAPI: `/query/explain`, `/aggregate`\n"
-     },
-     "accepts": {
-      "crates/velesdb-server/src/routes.rs": "pub fn build_router() {\n    Router::new()\n        .route(\"/query/explain\", post(explain))\n        .route(\"/aggregate\", post(aggregate))\n        .route(\"/collections/{name}/vacuum\", post(vacuum_collection));\n}\n",
-      "README.md": "# Test fixture\n\nAPI: `/query/explain`, `/aggregate`, `/collections/{name}/vacuum`\n"
-     },
-     "argv": []
-    }
-   ],
-   "required_via": "doc-contract"
-  },
-  {
-   "script": "scripts/check-doc-freshness.py",
-   "purpose": "Doc stamps, index, declarative and prose version references, the tracked-contract rule and the decisions index stay honest (five guards).",
-   "workflow": ".github/workflows/doc-contract.yml",
-   "job": "freshness",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_doc_freshness",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "None known. The `index` guard ran in warn mode over eleven root docs a comment called unreachable; measured, all eleven are linked and strict exits 0, so the comment had kept a working guard disarmed. All five guards are strict from here. `tracked` reads git, not the filesystem: a path that exists and a path a clone receives are not the same path. `decisions` sweeps docs/decisions/ only, non-recursively: a subdirectory is another index's business. Three limits it does not reach: docs/decisions/README.md is itself required by nothing, since `index` only sweeps the root of docs/; an index listing nothing, in a directory holding only that index, passes vacuously; and a listed file that exists but is untracked is `tracked`'s jurisdiction, not this one's."
-   },
-   "required_via": "doc-contract",
-   "must_refuse": [
-    {
-     "vector": "a current onboarding page naming packages from an older released VelesDB version in prose",
-     "files": {
-      "Cargo.toml": "[workspace.package]\nversion = \"5.0.0\"\n",
-      "crates/velesdb-memory/Cargo.toml": "[package]\nname = \"velesdb-memory\"\nversion = \"0.12.0\"\n",
-      "docs/getting-started.md": "# Getting started\n\nTimed against the published v4.3.0 packages.\n"
-     },
-     "accepts": {
-      "Cargo.toml": "[workspace.package]\nversion = \"5.0.0\"\n",
-      "crates/velesdb-memory/Cargo.toml": "[package]\nname = \"velesdb-memory\"\nversion = \"0.12.0\"\n",
-      "docs/getting-started.md": "# Getting started\n\nTimed against the published v5.0.0 packages.\n"
-     },
-     "argv": [
-      "--guard",
-      "versions",
-      "--mode",
-      "strict",
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "an entry document designating a file that exists but is NOT tracked — the shape that hid CLAUDE.md, AGENTS.md and CORE_PREMIUM_SPLIT.md behind .git/info/exclude",
-     "files": {
-      "AGENTS.md": "# Entry\n\nRead the [boundary contract](docs/BOUNDARY.md) before any change.\n",
-      "docs/BOUNDARY.md": "# Boundary\n\nvelesdb-core must never reference any premium crate.\n"
-     },
-     "accepts": {
-      "AGENTS.md": "# Entry\n\nRead the [boundary contract](docs/BOUNDARY.md) before any change.\n",
-      "docs/BOUNDARY.md": "# Boundary\n\nvelesdb-core must never reference any premium crate.\n"
-     },
-     "repo": {
-      "files": [
-       "AGENTS.md"
-      ],
-      "accepts": [
-       "AGENTS.md",
-       "docs/BOUNDARY.md"
+      "script": "scripts/check_prod_unwraps.py",
+      "purpose": "No .unwrap()/.expect() in production code (QUALITY_BAR Gate 3).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_prod_unwraps",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "None known. #1700 is closed: a #[cfg(test)] gate now skips ITS item by following braces instead of stopping the file, and block-comment tracking runs first so a marker quoted in /* */ no longer blinds it. Measured after the fix: the 33 914 formerly unread lines contain zero production unwrap/expect."
+      },
+      "must_refuse": [
+        {
+          "vector": "a production unwrap AFTER a #[cfg(test)] module — the 33 914-line blindness of #1700",
+          "files": {
+            "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\npub fn prod() { y.unwrap(); }\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\npub fn prod() { y.unwrap_or_default(); }\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a marker merely QUOTED in a /* */ comment must not blind the file",
+          "files": {
+            "crates/velesdb-core/src/lib.rs": "/*\n * #[cfg(test)]\n */\npub fn prod() { y.unwrap(); }\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/lib.rs": "/*\n * #[cfg(test)]\n */\npub fn prod() { y.unwrap_or_default(); }\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
       ]
-     },
-     "argv": [
-      "--guard",
-      "tracked",
-      "--mode",
-      "strict",
-      "--root",
-      "{root}"
-     ]
     },
     {
-     "vector": "a decision file present in docs/decisions/ that the index does not list — the orphan `index` cannot see, because it only sweeps the root of docs/",
-     "files": {
-      "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
-      "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n",
-      "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
-      "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
-     },
-     "accepts": {
-      "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
-      "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
-      "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
-      "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
-     },
-     "argv": [
-      "--guard",
-      "decisions",
-      "--mode",
-      "strict",
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "the decisions index listing a file that does not exist — the dead link `index` structurally cannot catch, since it only checks doc-to-index and never index-to-doc",
-     "files": {
-      "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
-      "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
-      "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n"
-     },
-     "accepts": {
-      "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
-      "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
-      "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
-      "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
-     },
-     "argv": [
-      "--guard",
-      "decisions",
-      "--mode",
-      "strict",
-      "--root",
-      "{root}"
-     ]
-    }
-   ],
-   "subguards": [
-    "stamp",
-    "index",
-    "versions",
-    "tracked",
-    "decisions"
-   ]
-  },
-  {
-   "script": "scripts/check-promise-contract.py",
-   "purpose": "The promise-contract registry stays valid.",
-   "workflow": ".github/workflows/promise-contract.yml",
-   "job": "contract",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_promise_contract",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "None known. Folded into CI Success's needs and chain via the `promise-contract` caller job, so a failure now blocks the merge."
-   },
-   "required_via": "promise-contract",
-   "must_refuse": [
-    {
-     "vector": "a capacity-mode doc promising sq8 buys search throughput — the overclaim Requirement 10.4 exists to refuse",
-     "files": {
-      "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
-      "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers higher throughput.\n",
-      "docs/VELESQL_SPEC.md": "# VelesQL\n",
-      "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
-      "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
-     },
-     "accepts": {
-      "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
-      "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
-      "docs/VELESQL_SPEC.md": "# VelesQL\n",
-      "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
-      "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    },
-    {
-     "vector": "an .mcpb recommendation pointing at the repository-wide latest release instead of the independent memory release train",
-     "files": {
-      "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
-      "README.md": "Get the `.mcpb` bundle from https://github.com/cyberlife-coder/VelesDB/releases/latest.\n",
-      "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
-      "docs/VELESQL_SPEC.md": "# VelesQL\n",
-      "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
-      "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
-     },
-     "accepts": {
-      "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
-      "README.md": "Get the `.mcpb` bundle from https://registry.modelcontextprotocol.io/.\n",
-      "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
-      "docs/VELESQL_SPEC.md": "# VelesQL\n",
-      "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
-      "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
-     },
-     "argv": [
-      "--root",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-python.sh",
-   "purpose": "Python integration checks (dangerous hash(), non-determinism, bandit, flake8 complexity).",
-   "workflow": ".github/workflows/propagation-guard.yml",
-   "job": "integrations-python",
-   "required": true,
-   "mode": "strict",
-   "self_test": null,
-   "self_test_required": false,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Entirely cwd-relative (PYTHON_DIRS) with no --root and no cd of its own: run from a subdirectory it scans nothing and exits 0 — measured from docs/. Harmless in CI, which runs it from the root, and it is what lets the refusal harness drive it with an empty argv. Only checks 1, 3 and 4 can raise ERRORS; 2 and 5 warn and can never refuse."
-   },
-   "required_via": "propagation-guard",
-   "must_refuse": [
-    {
-     "vector": "a builtin hash() used to derive a token — non-deterministic across processes, which is the whole point of check 1",
-     "files": {
-      "integrations/langchain/src/velesdb_langchain/store.py": "def token_for(doc):\n    return hash(doc)\n"
-     },
-     "accepts": {
-      "integrations/langchain/src/velesdb_langchain/store.py": "import hashlib\n\n\ndef token_for(doc):\n    return hashlib.sha256(doc).hexdigest()\n"
-     },
-     "argv": []
-    }
-   ]
-  },
-  {
-   "script": "scripts/check_binary_size.py",
-   "purpose": "Release binaries stay within their size ceilings.",
-   "workflow": ".github/workflows/binary-size.yml",
-   "job": "binary-size",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_binary_size",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Measures the apparent size of three binaries on the CI runner's target only (linux x86_64): the macOS and Windows release artifacts and the wasm bundle are outside its reach, as is any growth that stays under a ceiling. This field previously claimed the OVER-CEILING half was not vector-testable (a fixture exceeding a ceiling would mean carrying 9 MiB of literal bytes in this registry) and that it was exercised for real on every release. Both were false. The guard reads st_size, so a sparse fixture exceeds any ceiling for free - scripts.tests.test_check_binary_size now covers that half, including the boundary and a silently-raised ceiling. And the release build did produce over-ceiling binaries: binary-size.yml piped the guard into tee under a shell without pipefail, so the job took tee's exit status and reported success while the guard printed FAILED (#2193). The half declared exercised for real was the only half that could never turn a build red."
-   },
-   "required_via": "binary-size",
-   "must_refuse": [
-    {
-     "vector": "a release that built only two of its three binaries — the gate must not pass on a binary it never weighed",
-     "files": {
-      "velesdb-server": "stub\n",
-      "velesdb": "stub\n"
-     },
-     "accepts": {
-      "velesdb-server": "stub\n",
-      "velesdb": "stub\n",
-      "velesdb-migrate": "stub\n"
-     },
-     "argv": [
-      "--target-dir",
-      "{root}"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/run-production-gates.sh",
-   "purpose": "Meta-runner chaining the production gates.",
-   "workflow": ".github/workflows/production-gates.yml",
-   "job": "gates",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_run_production_gates",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
-   },
-   "required_via": "production-gates",
-   "subguards": [
-    "doc-contract",
-    "promise-contract",
-    "planner",
-    "crash-recovery",
-    "wal-recovery"
-   ],
-   "must_refuse": [
-    {
-     "vector": "the production meta-runner's doc-contract member sees a runtime route missing from README, then accepts the documented route",
-     "files": {
-      "crates/velesdb-server/src/routes.rs": ".route(\"/query/explain\", get(explain))\n.route(\"/aggregate\", post(aggregate))\n",
-      "README.md": "`/query/explain`\n"
-     },
-     "accepts": {
-      "crates/velesdb-server/src/routes.rs": ".route(\"/query/explain\", get(explain))\n.route(\"/aggregate\", post(aggregate))\n",
-      "README.md": "`/query/explain`\n`/aggregate`\n"
-     },
-     "argv": [
-      "--root",
-      "{root}",
-      "--guard",
-      "doc-contract"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-pr-governance.py",
-   "purpose": "Git Flow source/target rules and freshness of the branch against its fetched base.",
-   "workflow": ".github/workflows/pr-governance.yml",
-   "job": "governance",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_pr_governance",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "an archived PR source is refused while an admitted feature source targeting develop passes",
-     "files": {
-      "EVENT.txt": "pull request policy fixture\n"
-     },
-     "accepts": {
-      "EVENT.txt": "pull request policy fixture\n"
-     },
-     "argv": {
-      "files": [
-       "--guard",
-       "git-flow",
-       "--source-ref",
-       "archive/old-work",
-       "--base-ref",
-       "develop"
-      ],
-      "accepts": [
-       "--guard",
-       "git-flow",
-       "--source-ref",
-       "feat/current-work",
-       "--base-ref",
-       "develop"
+      "script": "scripts/check-inline-tests.py",
+      "purpose": "Freeze the inline-test-module debt: no new inline #[cfg(test)] mod {...} block, and no growth of an existing one, against a frozen baseline.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_inline_tests",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Line-based brace/bracket counting inherits check_prod_unwraps.py's known caveat: a multi-line string literal containing an unmatched brace or bracket can unbalance the count. Likewise line-based: a #[cfg(...)] attribute wrapped across several lines is not recognized as a gate (none exist in the tree today; rustfmt keeps cfg attributes on one line at current lengths)."
+      },
+      "must_refuse": [
+        {
+          "vector": "a new inline test module in a file the frozen baseline has never seen",
+          "files": {
+            "crates/velesdb-core/src/lib.rs": "pub fn a() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/lib.rs": "pub fn a() {}\n\n#[cfg(test)]\n#[path = \"lib_tests.rs\"]\nmod lib_tests;\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a baselined inline test module that grew past its frozen line count",
+          "files": {
+            "scripts/inline-tests-baseline.txt": "crates/velesdb-core/src/lib.rs\t4\n",
+            "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn a() {}\n    fn b() {}\n}\n"
+          },
+          "accepts": {
+            "scripts/inline-tests-baseline.txt": "crates/velesdb-core/src/lib.rs\t4\n",
+            "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
       ]
-     }
     },
     {
-     "vector": "a fetched base on a sibling commit is refused while the same base as an ancestor of HEAD passes",
-     "files": {
-      "TRACKED.txt": "branch topology fixture\n"
-     },
-     "accepts": {
-      "TRACKED.txt": "branch topology fixture\n"
-     },
-     "repo": {
-      "files": [
-       "TRACKED.txt"
+      "script": "scripts/check-file-budgets.py",
+      "purpose": "Freeze the count of over-budget (>1000-line) production Rust files: no file newly crosses the budget, no over-budget file grows, against a frozen baseline.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_file_budgets",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Raw line counts only: a file can stay under 1000 lines while its complexity grows (lizard's CCN gate polices that axis), and generated files are budgeted like hand-written ones - none exist under crates/*/src today."
+      },
+      "must_refuse": [
+        {
+          "vector": "a production file that newly crosses the 1000-line budget",
+          "files": {
+            "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\npub fn f999() {}\npub fn f1000() {}\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a baselined over-budget file that grew past its frozen line count",
+          "files": {
+            "scripts/file-budgets-baseline.txt": "crates/velesdb-core/src/lib.rs\t1001\n",
+            "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\npub fn f999() {}\npub fn f1000() {}\npub fn f1001() {}\n"
+          },
+          "accepts": {
+            "scripts/file-budgets-baseline.txt": "crates/velesdb-core/src/lib.rs\t1001\n",
+            "crates/velesdb-core/src/lib.rs": "pub fn f0() {}\npub fn f1() {}\npub fn f2() {}\npub fn f3() {}\npub fn f4() {}\npub fn f5() {}\npub fn f6() {}\npub fn f7() {}\npub fn f8() {}\npub fn f9() {}\npub fn f10() {}\npub fn f11() {}\npub fn f12() {}\npub fn f13() {}\npub fn f14() {}\npub fn f15() {}\npub fn f16() {}\npub fn f17() {}\npub fn f18() {}\npub fn f19() {}\npub fn f20() {}\npub fn f21() {}\npub fn f22() {}\npub fn f23() {}\npub fn f24() {}\npub fn f25() {}\npub fn f26() {}\npub fn f27() {}\npub fn f28() {}\npub fn f29() {}\npub fn f30() {}\npub fn f31() {}\npub fn f32() {}\npub fn f33() {}\npub fn f34() {}\npub fn f35() {}\npub fn f36() {}\npub fn f37() {}\npub fn f38() {}\npub fn f39() {}\npub fn f40() {}\npub fn f41() {}\npub fn f42() {}\npub fn f43() {}\npub fn f44() {}\npub fn f45() {}\npub fn f46() {}\npub fn f47() {}\npub fn f48() {}\npub fn f49() {}\npub fn f50() {}\npub fn f51() {}\npub fn f52() {}\npub fn f53() {}\npub fn f54() {}\npub fn f55() {}\npub fn f56() {}\npub fn f57() {}\npub fn f58() {}\npub fn f59() {}\npub fn f60() {}\npub fn f61() {}\npub fn f62() {}\npub fn f63() {}\npub fn f64() {}\npub fn f65() {}\npub fn f66() {}\npub fn f67() {}\npub fn f68() {}\npub fn f69() {}\npub fn f70() {}\npub fn f71() {}\npub fn f72() {}\npub fn f73() {}\npub fn f74() {}\npub fn f75() {}\npub fn f76() {}\npub fn f77() {}\npub fn f78() {}\npub fn f79() {}\npub fn f80() {}\npub fn f81() {}\npub fn f82() {}\npub fn f83() {}\npub fn f84() {}\npub fn f85() {}\npub fn f86() {}\npub fn f87() {}\npub fn f88() {}\npub fn f89() {}\npub fn f90() {}\npub fn f91() {}\npub fn f92() {}\npub fn f93() {}\npub fn f94() {}\npub fn f95() {}\npub fn f96() {}\npub fn f97() {}\npub fn f98() {}\npub fn f99() {}\npub fn f100() {}\npub fn f101() {}\npub fn f102() {}\npub fn f103() {}\npub fn f104() {}\npub fn f105() {}\npub fn f106() {}\npub fn f107() {}\npub fn f108() {}\npub fn f109() {}\npub fn f110() {}\npub fn f111() {}\npub fn f112() {}\npub fn f113() {}\npub fn f114() {}\npub fn f115() {}\npub fn f116() {}\npub fn f117() {}\npub fn f118() {}\npub fn f119() {}\npub fn f120() {}\npub fn f121() {}\npub fn f122() {}\npub fn f123() {}\npub fn f124() {}\npub fn f125() {}\npub fn f126() {}\npub fn f127() {}\npub fn f128() {}\npub fn f129() {}\npub fn f130() {}\npub fn f131() {}\npub fn f132() {}\npub fn f133() {}\npub fn f134() {}\npub fn f135() {}\npub fn f136() {}\npub fn f137() {}\npub fn f138() {}\npub fn f139() {}\npub fn f140() {}\npub fn f141() {}\npub fn f142() {}\npub fn f143() {}\npub fn f144() {}\npub fn f145() {}\npub fn f146() {}\npub fn f147() {}\npub fn f148() {}\npub fn f149() {}\npub fn f150() {}\npub fn f151() {}\npub fn f152() {}\npub fn f153() {}\npub fn f154() {}\npub fn f155() {}\npub fn f156() {}\npub fn f157() {}\npub fn f158() {}\npub fn f159() {}\npub fn f160() {}\npub fn f161() {}\npub fn f162() {}\npub fn f163() {}\npub fn f164() {}\npub fn f165() {}\npub fn f166() {}\npub fn f167() {}\npub fn f168() {}\npub fn f169() {}\npub fn f170() {}\npub fn f171() {}\npub fn f172() {}\npub fn f173() {}\npub fn f174() {}\npub fn f175() {}\npub fn f176() {}\npub fn f177() {}\npub fn f178() {}\npub fn f179() {}\npub fn f180() {}\npub fn f181() {}\npub fn f182() {}\npub fn f183() {}\npub fn f184() {}\npub fn f185() {}\npub fn f186() {}\npub fn f187() {}\npub fn f188() {}\npub fn f189() {}\npub fn f190() {}\npub fn f191() {}\npub fn f192() {}\npub fn f193() {}\npub fn f194() {}\npub fn f195() {}\npub fn f196() {}\npub fn f197() {}\npub fn f198() {}\npub fn f199() {}\npub fn f200() {}\npub fn f201() {}\npub fn f202() {}\npub fn f203() {}\npub fn f204() {}\npub fn f205() {}\npub fn f206() {}\npub fn f207() {}\npub fn f208() {}\npub fn f209() {}\npub fn f210() {}\npub fn f211() {}\npub fn f212() {}\npub fn f213() {}\npub fn f214() {}\npub fn f215() {}\npub fn f216() {}\npub fn f217() {}\npub fn f218() {}\npub fn f219() {}\npub fn f220() {}\npub fn f221() {}\npub fn f222() {}\npub fn f223() {}\npub fn f224() {}\npub fn f225() {}\npub fn f226() {}\npub fn f227() {}\npub fn f228() {}\npub fn f229() {}\npub fn f230() {}\npub fn f231() {}\npub fn f232() {}\npub fn f233() {}\npub fn f234() {}\npub fn f235() {}\npub fn f236() {}\npub fn f237() {}\npub fn f238() {}\npub fn f239() {}\npub fn f240() {}\npub fn f241() {}\npub fn f242() {}\npub fn f243() {}\npub fn f244() {}\npub fn f245() {}\npub fn f246() {}\npub fn f247() {}\npub fn f248() {}\npub fn f249() {}\npub fn f250() {}\npub fn f251() {}\npub fn f252() {}\npub fn f253() {}\npub fn f254() {}\npub fn f255() {}\npub fn f256() {}\npub fn f257() {}\npub fn f258() {}\npub fn f259() {}\npub fn f260() {}\npub fn f261() {}\npub fn f262() {}\npub fn f263() {}\npub fn f264() {}\npub fn f265() {}\npub fn f266() {}\npub fn f267() {}\npub fn f268() {}\npub fn f269() {}\npub fn f270() {}\npub fn f271() {}\npub fn f272() {}\npub fn f273() {}\npub fn f274() {}\npub fn f275() {}\npub fn f276() {}\npub fn f277() {}\npub fn f278() {}\npub fn f279() {}\npub fn f280() {}\npub fn f281() {}\npub fn f282() {}\npub fn f283() {}\npub fn f284() {}\npub fn f285() {}\npub fn f286() {}\npub fn f287() {}\npub fn f288() {}\npub fn f289() {}\npub fn f290() {}\npub fn f291() {}\npub fn f292() {}\npub fn f293() {}\npub fn f294() {}\npub fn f295() {}\npub fn f296() {}\npub fn f297() {}\npub fn f298() {}\npub fn f299() {}\npub fn f300() {}\npub fn f301() {}\npub fn f302() {}\npub fn f303() {}\npub fn f304() {}\npub fn f305() {}\npub fn f306() {}\npub fn f307() {}\npub fn f308() {}\npub fn f309() {}\npub fn f310() {}\npub fn f311() {}\npub fn f312() {}\npub fn f313() {}\npub fn f314() {}\npub fn f315() {}\npub fn f316() {}\npub fn f317() {}\npub fn f318() {}\npub fn f319() {}\npub fn f320() {}\npub fn f321() {}\npub fn f322() {}\npub fn f323() {}\npub fn f324() {}\npub fn f325() {}\npub fn f326() {}\npub fn f327() {}\npub fn f328() {}\npub fn f329() {}\npub fn f330() {}\npub fn f331() {}\npub fn f332() {}\npub fn f333() {}\npub fn f334() {}\npub fn f335() {}\npub fn f336() {}\npub fn f337() {}\npub fn f338() {}\npub fn f339() {}\npub fn f340() {}\npub fn f341() {}\npub fn f342() {}\npub fn f343() {}\npub fn f344() {}\npub fn f345() {}\npub fn f346() {}\npub fn f347() {}\npub fn f348() {}\npub fn f349() {}\npub fn f350() {}\npub fn f351() {}\npub fn f352() {}\npub fn f353() {}\npub fn f354() {}\npub fn f355() {}\npub fn f356() {}\npub fn f357() {}\npub fn f358() {}\npub fn f359() {}\npub fn f360() {}\npub fn f361() {}\npub fn f362() {}\npub fn f363() {}\npub fn f364() {}\npub fn f365() {}\npub fn f366() {}\npub fn f367() {}\npub fn f368() {}\npub fn f369() {}\npub fn f370() {}\npub fn f371() {}\npub fn f372() {}\npub fn f373() {}\npub fn f374() {}\npub fn f375() {}\npub fn f376() {}\npub fn f377() {}\npub fn f378() {}\npub fn f379() {}\npub fn f380() {}\npub fn f381() {}\npub fn f382() {}\npub fn f383() {}\npub fn f384() {}\npub fn f385() {}\npub fn f386() {}\npub fn f387() {}\npub fn f388() {}\npub fn f389() {}\npub fn f390() {}\npub fn f391() {}\npub fn f392() {}\npub fn f393() {}\npub fn f394() {}\npub fn f395() {}\npub fn f396() {}\npub fn f397() {}\npub fn f398() {}\npub fn f399() {}\npub fn f400() {}\npub fn f401() {}\npub fn f402() {}\npub fn f403() {}\npub fn f404() {}\npub fn f405() {}\npub fn f406() {}\npub fn f407() {}\npub fn f408() {}\npub fn f409() {}\npub fn f410() {}\npub fn f411() {}\npub fn f412() {}\npub fn f413() {}\npub fn f414() {}\npub fn f415() {}\npub fn f416() {}\npub fn f417() {}\npub fn f418() {}\npub fn f419() {}\npub fn f420() {}\npub fn f421() {}\npub fn f422() {}\npub fn f423() {}\npub fn f424() {}\npub fn f425() {}\npub fn f426() {}\npub fn f427() {}\npub fn f428() {}\npub fn f429() {}\npub fn f430() {}\npub fn f431() {}\npub fn f432() {}\npub fn f433() {}\npub fn f434() {}\npub fn f435() {}\npub fn f436() {}\npub fn f437() {}\npub fn f438() {}\npub fn f439() {}\npub fn f440() {}\npub fn f441() {}\npub fn f442() {}\npub fn f443() {}\npub fn f444() {}\npub fn f445() {}\npub fn f446() {}\npub fn f447() {}\npub fn f448() {}\npub fn f449() {}\npub fn f450() {}\npub fn f451() {}\npub fn f452() {}\npub fn f453() {}\npub fn f454() {}\npub fn f455() {}\npub fn f456() {}\npub fn f457() {}\npub fn f458() {}\npub fn f459() {}\npub fn f460() {}\npub fn f461() {}\npub fn f462() {}\npub fn f463() {}\npub fn f464() {}\npub fn f465() {}\npub fn f466() {}\npub fn f467() {}\npub fn f468() {}\npub fn f469() {}\npub fn f470() {}\npub fn f471() {}\npub fn f472() {}\npub fn f473() {}\npub fn f474() {}\npub fn f475() {}\npub fn f476() {}\npub fn f477() {}\npub fn f478() {}\npub fn f479() {}\npub fn f480() {}\npub fn f481() {}\npub fn f482() {}\npub fn f483() {}\npub fn f484() {}\npub fn f485() {}\npub fn f486() {}\npub fn f487() {}\npub fn f488() {}\npub fn f489() {}\npub fn f490() {}\npub fn f491() {}\npub fn f492() {}\npub fn f493() {}\npub fn f494() {}\npub fn f495() {}\npub fn f496() {}\npub fn f497() {}\npub fn f498() {}\npub fn f499() {}\npub fn f500() {}\npub fn f501() {}\npub fn f502() {}\npub fn f503() {}\npub fn f504() {}\npub fn f505() {}\npub fn f506() {}\npub fn f507() {}\npub fn f508() {}\npub fn f509() {}\npub fn f510() {}\npub fn f511() {}\npub fn f512() {}\npub fn f513() {}\npub fn f514() {}\npub fn f515() {}\npub fn f516() {}\npub fn f517() {}\npub fn f518() {}\npub fn f519() {}\npub fn f520() {}\npub fn f521() {}\npub fn f522() {}\npub fn f523() {}\npub fn f524() {}\npub fn f525() {}\npub fn f526() {}\npub fn f527() {}\npub fn f528() {}\npub fn f529() {}\npub fn f530() {}\npub fn f531() {}\npub fn f532() {}\npub fn f533() {}\npub fn f534() {}\npub fn f535() {}\npub fn f536() {}\npub fn f537() {}\npub fn f538() {}\npub fn f539() {}\npub fn f540() {}\npub fn f541() {}\npub fn f542() {}\npub fn f543() {}\npub fn f544() {}\npub fn f545() {}\npub fn f546() {}\npub fn f547() {}\npub fn f548() {}\npub fn f549() {}\npub fn f550() {}\npub fn f551() {}\npub fn f552() {}\npub fn f553() {}\npub fn f554() {}\npub fn f555() {}\npub fn f556() {}\npub fn f557() {}\npub fn f558() {}\npub fn f559() {}\npub fn f560() {}\npub fn f561() {}\npub fn f562() {}\npub fn f563() {}\npub fn f564() {}\npub fn f565() {}\npub fn f566() {}\npub fn f567() {}\npub fn f568() {}\npub fn f569() {}\npub fn f570() {}\npub fn f571() {}\npub fn f572() {}\npub fn f573() {}\npub fn f574() {}\npub fn f575() {}\npub fn f576() {}\npub fn f577() {}\npub fn f578() {}\npub fn f579() {}\npub fn f580() {}\npub fn f581() {}\npub fn f582() {}\npub fn f583() {}\npub fn f584() {}\npub fn f585() {}\npub fn f586() {}\npub fn f587() {}\npub fn f588() {}\npub fn f589() {}\npub fn f590() {}\npub fn f591() {}\npub fn f592() {}\npub fn f593() {}\npub fn f594() {}\npub fn f595() {}\npub fn f596() {}\npub fn f597() {}\npub fn f598() {}\npub fn f599() {}\npub fn f600() {}\npub fn f601() {}\npub fn f602() {}\npub fn f603() {}\npub fn f604() {}\npub fn f605() {}\npub fn f606() {}\npub fn f607() {}\npub fn f608() {}\npub fn f609() {}\npub fn f610() {}\npub fn f611() {}\npub fn f612() {}\npub fn f613() {}\npub fn f614() {}\npub fn f615() {}\npub fn f616() {}\npub fn f617() {}\npub fn f618() {}\npub fn f619() {}\npub fn f620() {}\npub fn f621() {}\npub fn f622() {}\npub fn f623() {}\npub fn f624() {}\npub fn f625() {}\npub fn f626() {}\npub fn f627() {}\npub fn f628() {}\npub fn f629() {}\npub fn f630() {}\npub fn f631() {}\npub fn f632() {}\npub fn f633() {}\npub fn f634() {}\npub fn f635() {}\npub fn f636() {}\npub fn f637() {}\npub fn f638() {}\npub fn f639() {}\npub fn f640() {}\npub fn f641() {}\npub fn f642() {}\npub fn f643() {}\npub fn f644() {}\npub fn f645() {}\npub fn f646() {}\npub fn f647() {}\npub fn f648() {}\npub fn f649() {}\npub fn f650() {}\npub fn f651() {}\npub fn f652() {}\npub fn f653() {}\npub fn f654() {}\npub fn f655() {}\npub fn f656() {}\npub fn f657() {}\npub fn f658() {}\npub fn f659() {}\npub fn f660() {}\npub fn f661() {}\npub fn f662() {}\npub fn f663() {}\npub fn f664() {}\npub fn f665() {}\npub fn f666() {}\npub fn f667() {}\npub fn f668() {}\npub fn f669() {}\npub fn f670() {}\npub fn f671() {}\npub fn f672() {}\npub fn f673() {}\npub fn f674() {}\npub fn f675() {}\npub fn f676() {}\npub fn f677() {}\npub fn f678() {}\npub fn f679() {}\npub fn f680() {}\npub fn f681() {}\npub fn f682() {}\npub fn f683() {}\npub fn f684() {}\npub fn f685() {}\npub fn f686() {}\npub fn f687() {}\npub fn f688() {}\npub fn f689() {}\npub fn f690() {}\npub fn f691() {}\npub fn f692() {}\npub fn f693() {}\npub fn f694() {}\npub fn f695() {}\npub fn f696() {}\npub fn f697() {}\npub fn f698() {}\npub fn f699() {}\npub fn f700() {}\npub fn f701() {}\npub fn f702() {}\npub fn f703() {}\npub fn f704() {}\npub fn f705() {}\npub fn f706() {}\npub fn f707() {}\npub fn f708() {}\npub fn f709() {}\npub fn f710() {}\npub fn f711() {}\npub fn f712() {}\npub fn f713() {}\npub fn f714() {}\npub fn f715() {}\npub fn f716() {}\npub fn f717() {}\npub fn f718() {}\npub fn f719() {}\npub fn f720() {}\npub fn f721() {}\npub fn f722() {}\npub fn f723() {}\npub fn f724() {}\npub fn f725() {}\npub fn f726() {}\npub fn f727() {}\npub fn f728() {}\npub fn f729() {}\npub fn f730() {}\npub fn f731() {}\npub fn f732() {}\npub fn f733() {}\npub fn f734() {}\npub fn f735() {}\npub fn f736() {}\npub fn f737() {}\npub fn f738() {}\npub fn f739() {}\npub fn f740() {}\npub fn f741() {}\npub fn f742() {}\npub fn f743() {}\npub fn f744() {}\npub fn f745() {}\npub fn f746() {}\npub fn f747() {}\npub fn f748() {}\npub fn f749() {}\npub fn f750() {}\npub fn f751() {}\npub fn f752() {}\npub fn f753() {}\npub fn f754() {}\npub fn f755() {}\npub fn f756() {}\npub fn f757() {}\npub fn f758() {}\npub fn f759() {}\npub fn f760() {}\npub fn f761() {}\npub fn f762() {}\npub fn f763() {}\npub fn f764() {}\npub fn f765() {}\npub fn f766() {}\npub fn f767() {}\npub fn f768() {}\npub fn f769() {}\npub fn f770() {}\npub fn f771() {}\npub fn f772() {}\npub fn f773() {}\npub fn f774() {}\npub fn f775() {}\npub fn f776() {}\npub fn f777() {}\npub fn f778() {}\npub fn f779() {}\npub fn f780() {}\npub fn f781() {}\npub fn f782() {}\npub fn f783() {}\npub fn f784() {}\npub fn f785() {}\npub fn f786() {}\npub fn f787() {}\npub fn f788() {}\npub fn f789() {}\npub fn f790() {}\npub fn f791() {}\npub fn f792() {}\npub fn f793() {}\npub fn f794() {}\npub fn f795() {}\npub fn f796() {}\npub fn f797() {}\npub fn f798() {}\npub fn f799() {}\npub fn f800() {}\npub fn f801() {}\npub fn f802() {}\npub fn f803() {}\npub fn f804() {}\npub fn f805() {}\npub fn f806() {}\npub fn f807() {}\npub fn f808() {}\npub fn f809() {}\npub fn f810() {}\npub fn f811() {}\npub fn f812() {}\npub fn f813() {}\npub fn f814() {}\npub fn f815() {}\npub fn f816() {}\npub fn f817() {}\npub fn f818() {}\npub fn f819() {}\npub fn f820() {}\npub fn f821() {}\npub fn f822() {}\npub fn f823() {}\npub fn f824() {}\npub fn f825() {}\npub fn f826() {}\npub fn f827() {}\npub fn f828() {}\npub fn f829() {}\npub fn f830() {}\npub fn f831() {}\npub fn f832() {}\npub fn f833() {}\npub fn f834() {}\npub fn f835() {}\npub fn f836() {}\npub fn f837() {}\npub fn f838() {}\npub fn f839() {}\npub fn f840() {}\npub fn f841() {}\npub fn f842() {}\npub fn f843() {}\npub fn f844() {}\npub fn f845() {}\npub fn f846() {}\npub fn f847() {}\npub fn f848() {}\npub fn f849() {}\npub fn f850() {}\npub fn f851() {}\npub fn f852() {}\npub fn f853() {}\npub fn f854() {}\npub fn f855() {}\npub fn f856() {}\npub fn f857() {}\npub fn f858() {}\npub fn f859() {}\npub fn f860() {}\npub fn f861() {}\npub fn f862() {}\npub fn f863() {}\npub fn f864() {}\npub fn f865() {}\npub fn f866() {}\npub fn f867() {}\npub fn f868() {}\npub fn f869() {}\npub fn f870() {}\npub fn f871() {}\npub fn f872() {}\npub fn f873() {}\npub fn f874() {}\npub fn f875() {}\npub fn f876() {}\npub fn f877() {}\npub fn f878() {}\npub fn f879() {}\npub fn f880() {}\npub fn f881() {}\npub fn f882() {}\npub fn f883() {}\npub fn f884() {}\npub fn f885() {}\npub fn f886() {}\npub fn f887() {}\npub fn f888() {}\npub fn f889() {}\npub fn f890() {}\npub fn f891() {}\npub fn f892() {}\npub fn f893() {}\npub fn f894() {}\npub fn f895() {}\npub fn f896() {}\npub fn f897() {}\npub fn f898() {}\npub fn f899() {}\npub fn f900() {}\npub fn f901() {}\npub fn f902() {}\npub fn f903() {}\npub fn f904() {}\npub fn f905() {}\npub fn f906() {}\npub fn f907() {}\npub fn f908() {}\npub fn f909() {}\npub fn f910() {}\npub fn f911() {}\npub fn f912() {}\npub fn f913() {}\npub fn f914() {}\npub fn f915() {}\npub fn f916() {}\npub fn f917() {}\npub fn f918() {}\npub fn f919() {}\npub fn f920() {}\npub fn f921() {}\npub fn f922() {}\npub fn f923() {}\npub fn f924() {}\npub fn f925() {}\npub fn f926() {}\npub fn f927() {}\npub fn f928() {}\npub fn f929() {}\npub fn f930() {}\npub fn f931() {}\npub fn f932() {}\npub fn f933() {}\npub fn f934() {}\npub fn f935() {}\npub fn f936() {}\npub fn f937() {}\npub fn f938() {}\npub fn f939() {}\npub fn f940() {}\npub fn f941() {}\npub fn f942() {}\npub fn f943() {}\npub fn f944() {}\npub fn f945() {}\npub fn f946() {}\npub fn f947() {}\npub fn f948() {}\npub fn f949() {}\npub fn f950() {}\npub fn f951() {}\npub fn f952() {}\npub fn f953() {}\npub fn f954() {}\npub fn f955() {}\npub fn f956() {}\npub fn f957() {}\npub fn f958() {}\npub fn f959() {}\npub fn f960() {}\npub fn f961() {}\npub fn f962() {}\npub fn f963() {}\npub fn f964() {}\npub fn f965() {}\npub fn f966() {}\npub fn f967() {}\npub fn f968() {}\npub fn f969() {}\npub fn f970() {}\npub fn f971() {}\npub fn f972() {}\npub fn f973() {}\npub fn f974() {}\npub fn f975() {}\npub fn f976() {}\npub fn f977() {}\npub fn f978() {}\npub fn f979() {}\npub fn f980() {}\npub fn f981() {}\npub fn f982() {}\npub fn f983() {}\npub fn f984() {}\npub fn f985() {}\npub fn f986() {}\npub fn f987() {}\npub fn f988() {}\npub fn f989() {}\npub fn f990() {}\npub fn f991() {}\npub fn f992() {}\npub fn f993() {}\npub fn f994() {}\npub fn f995() {}\npub fn f996() {}\npub fn f997() {}\npub fn f998() {}\npub fn f999() {}\npub fn f1000() {}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/check-trait-forwarding.py",
+      "purpose": "Every adapter that exists only to delegate forwards its trait WHOLE: the generic wrapper `impl<T: Trait + ?Sized> Trait for Box<T>|Arc<T>|Rc<T>`, and the erased alias `impl Trait for DynTrait` where `type DynTrait = Box<dyn Trait>` (the shape a binding holds). rustc already refuses an impl missing a *required* method, so a partial forwarding can only drop a method with a default body — which compiles and silently runs the default instead of the concrete override (the #1690-#1692 gap family). A plain `impl Trait for Backend` is deliberately exempt: a concrete backend is entitled to the default. velesdb-memory's doctrine (src/lib.rs) states the rule; this guard is what makes it hold without a reviewer noticing.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_trait_forwarding",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Presence, not delegation: a forwarded method whose body ignores `(**self)` and reimplements the default satisfies the guard — only review catches that. Three further limits, each currently vacuous under crates/*/src: a `#[cfg]`-gated trait method is demanded unconditionally; an impl or alias produced by a macro is invisible to the text scan; and a trait defined outside the scanned tree is reported SKIPPED rather than checked, so a forwarding of a foreign trait is announced as unverified instead of passing quietly."
+      },
+      "must_refuse": [
+        {
+          "vector": "a wrapper forwarding that drops the trait's defaulted method — the #1692 shape rustc cannot catch",
+          "files": {
+            "crates/velesdb-memory/src/extract.rs": "pub struct Doc;\npub struct Graph;\n\n/// Reproduces the #1692 shape: a defaulted method next to a required one.\npub trait Extractor: Send + Sync {\n    fn extract(&self, input: &str) -> Doc;\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        let _ = input;\n        Graph\n    }\n}\n\nimpl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {\n    fn extract(&self, input: &str) -> Doc {\n        (**self).extract(input)\n    }\n}\n"
+          },
+          "accepts": {
+            "crates/velesdb-memory/src/extract.rs": "pub struct Doc;\npub struct Graph;\n\n/// Reproduces the #1692 shape: a defaulted method next to a required one.\npub trait Extractor: Send + Sync {\n    fn extract(&self, input: &str) -> Doc;\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        let _ = input;\n        Graph\n    }\n}\n\nimpl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {\n    fn extract(&self, input: &str) -> Doc {\n        (**self).extract(input)\n    }\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        (**self).extract_graph(input)\n    }\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a partial forwarding whose trait is declared in a different file, so the miss is invisible at the impl site",
+          "files": {
+            "crates/velesdb-memory/src/context/estimator.rs": "pub trait TokenEstimator: Send + Sync {\n    fn estimate(&self, text: &str) -> usize;\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        4.0\n    }\n}\n",
+            "crates/velesdb-memory/src/context/boxed.rs": "use super::estimator::TokenEstimator;\n\nimpl<T: TokenEstimator + ?Sized> TokenEstimator for Box<T> {\n    fn estimate(&self, text: &str) -> usize {\n        (**self).estimate(text)\n    }\n}\n"
+          },
+          "accepts": {
+            "crates/velesdb-memory/src/context/estimator.rs": "pub trait TokenEstimator: Send + Sync {\n    fn estimate(&self, text: &str) -> usize;\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        4.0\n    }\n}\n",
+            "crates/velesdb-memory/src/context/boxed.rs": "use super::estimator::TokenEstimator;\n\nimpl<T: TokenEstimator + ?Sized> TokenEstimator for Box<T> {\n    fn estimate(&self, text: &str) -> usize {\n        (**self).estimate(text)\n    }\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        (**self).bytes_per_token_hint()\n    }\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a partial forwarding on an erased `Dyn*` alias — the shape a binding holds, and the one with no generic parameter to pattern-match on",
+          "files": {
+            "crates/velesdb-memory/src/rerank.rs": "pub trait Reranker {\n    fn rerank(&self, query: &str) -> u8;\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        queries.len() as u8\n    }\n}\n\n/// The shape a binding holds: no generic parameter, so the wrapper pattern\n/// alone never sees this impl.\npub type DynReranker = Box<dyn Reranker + Send + Sync>;\n\nimpl Reranker for DynReranker {\n    fn rerank(&self, query: &str) -> u8 {\n        (**self).rerank(query)\n    }\n}\n"
+          },
+          "accepts": {
+            "crates/velesdb-memory/src/rerank.rs": "pub trait Reranker {\n    fn rerank(&self, query: &str) -> u8;\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        queries.len() as u8\n    }\n}\n\n/// The shape a binding holds: no generic parameter, so the wrapper pattern\n/// alone never sees this impl.\npub type DynReranker = Box<dyn Reranker + Send + Sync>;\n\nimpl Reranker for DynReranker {\n    fn rerank(&self, query: &str) -> u8 {\n        (**self).rerank(query)\n    }\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        (**self).rerank_batch(queries)\n    }\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/verify_unsafe_safety_template.py",
+      "purpose": "Every unsafe block carries a // SAFETY: comment (Gate 4).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "must_refuse": [
+        {
+          "vector": "an unsafe block with no SAFETY comment in front of it",
+          "files": {
+            "src/lib.rs": "pub fn write(target: *mut u8) {\n    unsafe {\n        *target = 1;\n    }\n}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // - `target` is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases `target` for the duration of this call\n    // Reason: the caller owns the allocation and cannot express that in the type.\n    unsafe {\n        *target = 1;\n    }\n}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        },
+        {
+          "vector": "a second SAFETY header restating the one above it, with no condition bullet between them",
+          "files": {
+            "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // SAFETY: writing through the caller's pointer is sound.\n    // - target is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases target for the duration of this call\n    // Reason: the caller owns the allocation and cannot express that in the type.\n    unsafe {\n        *target = 1;\n    }\n}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // - target is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases target for the duration of this call\n    // SAFETY: writing through the caller's pointer is sound.\n    unsafe {\n        *target = 1;\n    }\n}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        }
       ],
-      "accepts": [
-       "TRACKED.txt"
-      ],
-      "relation": {
-       "files": "diverged",
-       "accepts": "ancestor"
+      "blind_spot": {
+        "issue": null,
+        "summary": "Runs only on production .rs files changed by the PR, so it never re-reads unsafe blocks that predate it. Until the `lint` job checked out full history, that diff resolved to nothing at all and the gate read no files on any pull request; test_ci_gate_reachability now pins the fetch-depth."
       }
-     },
-     "argv": [
-      "--guard",
-      "freshness",
-      "--root",
-      "{root}",
-      "--base-ref",
-      "develop",
-      "--base-commit",
-      "refs/heads/vector-base"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "The GitHub event-to-CLI mapping remains YAML's responsibility. The wiring contract pins both explicit --guard selectors; unit tests and vectors cover the policy and real git topology after that boundary. AI attribution is a separate executable guard in the same job."
-   },
-   "required_via": "pr-governance",
-   "subguards": [
-    "git-flow",
-    "freshness"
-   ]
-  },
-  {
-   "script": "scripts/check-ai-attribution.py",
-   "purpose": "No commit is authored by, or attributed to, an AI assistant (CLAUDE.md #5).",
-   "workflow": ".github/workflows/pr-governance.yml",
-   "job": "governance",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_ai_attribution",
-   "self_test_required": true,
-   "must_refuse": [
+    },
     {
-     "vector": "a commit whose author identity is an assistant, against the same tree authored by a person whose name merely starts the same way",
-     "files": {
-      "NOTES.md": "placeholder\n"
-     },
-     "accepts": {
-      "NOTES.md": "placeholder\n"
-     },
-     "repo": {
-      "files": [
-       "NOTES.md"
+      "script": "scripts/check-todo-annotations.py",
+      "purpose": "TODO/FIXME/HACK follow the // TODO(EPIC-XXX): governance format.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "must_refuse": [
+        {
+          "vector": "a TODO carrying no EPIC/US tag and no issue number",
+          "files": {
+            "src/lib.rs": "// TODO: rewrite this once the index lands\npub fn f() {}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "// TODO(EPIC-042): rewrite this once the index lands\npub fn f() {}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        },
+        {
+          "vector": "a FIXME carrying no tag — the verb changes, the obligation does not",
+          "files": {
+            "src/lib.rs": "// FIXME: the cast overflows above 2^53\npub fn f() {}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "// FIXME(#1468): the cast overflows above 2^53\npub fn f() {}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        }
       ],
-      "accepts": [
-       "NOTES.md"
-      ],
-      "author": {
-       "files": "Claude <claude@anthropic.com>",
-       "accepts": "Claudette <claudette@example.com>"
+      "blind_spot": {
+        "issue": null,
+        "summary": "Diff-scoped to changed velesdb-core production files, like the unsafe guard — and it shared the same shallow-checkout blind spot, now pinned by test_ci_gate_reachability."
       }
-     },
-     "argv": [
-      "HEAD",
-      "--root",
-      "{root}"
-     ]
     },
     {
-    "vector": "a pull request body carrying the attribution footer tooling appends on publish",
-    "files": {
-     "pr-body.md": "## Description\n\nA real change.\n\n---\n_Generated by [Claude Code](https://claude.ai/code)_\n"
-    },
-    "accepts": {
-     "pr-body.md": "## Description\n\nA real change.\n"
-    },
-    "argv": [
-     "--text",
-     "{root}/pr-body.md",
-     "--surface",
-     "pull request body"
-    ]
-   }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "Reads the RAW identity (%an <%ae>, never %aN): a .mailmap line in this repository already maps anthropic to the maintainer, and the mapped name would launder the case being looked for. Admission is by whole identity, so an impostor of an admitted bot does not inherit it. --text covers the pull request title and description and --tree covers tracked repository content, but NOT issue or PR comments: no workflow trigger delivers a comment body to this guard today, so a footer pasted into a comment is still caught only by review. Title and body are read from the event payload, and ci.yml skips an 'edited' event that does not change the base (the #22 fix that stopped no-op edits cancelling real runs), so a footer added by EDITING a description after the run is not re-checked; creation, pushes and reopens are. --tree strips a comment or blockquote leader before applying the rule, which the commit-message path deliberately does not, so a source line quoting a trailer behind // or # is refused there and accepted in a commit message describing it. --tree has no must_refuse vector: the harness materialises a refusal by copying the tracked tree (base: repository), and a mode that then reads every file in that copy exhausts the runner. Its refusal is covered by unit tests instead, including a positive control that the checked-in tree passes. Its URL pattern is also unanchored, unlike the trailer patterns, so a body that quotes the footer verbatim in order to DESCRIBE the rule is refused along with one that carries it; write the URL in parts when documenting it, as this repo's own tests do."
-   },
-   "required_via": "pr-governance"
-  },
-  {
-   "script": "scripts/run-node-binding-tests.py",
-   "purpose": "The Node binding's functional gate: build the napi addon (debug profile) and run every __test__/*.spec.mjs suite via `npm test`.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "node-binding-tests",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_ci_test_gate",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "the Linux N-API pipeline reaches a failing npm test after install and build, then propagates a repaired tool's success",
-     "files": {
-      "crates/velesdb-node/.fixture": "package root\n",
-      "tools/fake-ci-tool": "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1 if sys.argv[1:] == ['test'] else 0)\n"
-     },
-     "accepts": {
-      "crates/velesdb-node/.fixture": "package root\n",
-      "tools/fake-ci-tool": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
-     },
-     "executable": {
-      "files": [
-       "tools/fake-ci-tool"
-      ],
-      "accepts": [
-       "tools/fake-ci-tool"
+      "script": "scripts/check-version-sync.py",
+      "purpose": "Version equality across policed manifests (REL-07), at PR time.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_version_sync",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "None known. Its self-test is reached by gate-contracts.yml's `unittest discover`, which the fold made required through the `gate-contracts` caller job."
+      },
+      "must_refuse": [
+        {
+          "vector": "a manifest stamped 9.9.9 against a 1.0.0 workspace — the drift this guard exists for",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n\n[workspace.dependencies]\nvelesdb-core = { path = \"crates/velesdb-core\", version = \"1.0.0\" }\n",
+            "crates/velesdb-memory/Cargo.toml": "version = \"1.0.0\"\n",
+            "crates/velesdb-python/pyproject.toml": "[project]\nversion = \"9.9.9\"\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n\n[workspace.dependencies]\nvelesdb-core = { path = \"crates/velesdb-core\", version = \"1.0.0\" }\n",
+            "crates/velesdb-memory/Cargo.toml": "version = \"1.0.0\"\n",
+            "crates/velesdb-python/pyproject.toml": "[project]\nversion = \"1.0.0\"\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
       ]
-     },
-     "argv": [
-      "--root",
-      "{root}",
-      "--npm",
-      "{root}/tools/fake-ci-tool",
-      "--npx",
-      "{root}/tools/fake-ci-tool"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "The vector dependency-injects npm/npx to prove the exact three-stage sequence and exit propagation without compiling the addon twice. The required CI job still supplies the real tools and crate; the Node suites own addon semantics."
-   }
-  },
-  {
-   "script": "scripts/run-node-binding-tests-windows.py",
-   "purpose": "The Windows leg of the Node binding gate (#1515): the same napi build, then `node --test __test__/index.spec.mjs` — the file that carries the three Windows-only regressions (#1509, #1510, #1511).",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "node-binding-tests-windows",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_ci_test_gate",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "the Windows N-API pipeline reaches a failing explicit Node spec after install and build, then propagates success",
-     "files": {
-      "crates/velesdb-node/.fixture": "package root\n",
-      "tools/fake-ci-tool": "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1 if sys.argv[1:2] == ['--test'] else 0)\n"
-     },
-     "accepts": {
-      "crates/velesdb-node/.fixture": "package root\n",
-      "tools/fake-ci-tool": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
-     },
-     "executable": {
-      "files": [
-       "tools/fake-ci-tool"
-      ],
-      "accepts": [
-       "tools/fake-ci-tool"
-      ]
-     },
-     "argv": [
-      "--root",
-      "{root}",
-      "--npm",
-      "{root}/tools/fake-ci-tool",
-      "--npx",
-      "{root}/tools/fake-ci-tool",
-      "--node",
-      "{root}/tools/fake-ci-tool"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "The job remains path-filtered by node-windows-changed, so PRs outside crates/velesdb-node intentionally no-op. The command contract pins the Windows-specific explicit spec; the vector substitutes tools only to make its refusal hermetic."
-   }
-  },
-  {
-   "script": "scripts/run-wasm-bindgen-tests.py",
-   "purpose": "The WASM functional gate: `wasm-pack test --node crates/velesdb-wasm` runs the wasm-bindgen suites (tests/*.rs gated on target_arch = \"wasm32\") that compile to empty binaries under the native test job and are invisible to `cargo check`.",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "wasm-check",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_ci_test_gate",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "the wasm-bindgen Node runner propagates wasm-pack's refusal and accepts the repaired tool",
-     "files": {
-      "crates/velesdb-wasm/.fixture": "crate root\n",
-      "tools/fake-wasm-pack": "#!/usr/bin/env python3\nraise SystemExit(1)\n"
-     },
-     "accepts": {
-      "crates/velesdb-wasm/.fixture": "crate root\n",
-      "tools/fake-wasm-pack": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
-     },
-     "executable": {
-      "files": [
-       "tools/fake-wasm-pack"
-      ],
-      "accepts": [
-       "tools/fake-wasm-pack"
-      ]
-     },
-     "argv": [
-      "--root",
-      "{root}",
-      "--wasm-pack",
-      "{root}/tools/fake-wasm-pack"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "The vector substitutes wasm-pack to prove command shape and refusal propagation without installing the wasm toolchain in gate-contracts. The required wasm-check job supplies real wasm-pack and owns wasm32 suite semantics."
-   }
-  },
-  {
-   "script": "scripts/compare_perf.py",
-   "purpose": "A benchmark that regresses past its threshold fails the build (perf-smoke).",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "perf-smoke",
-   "required": true,
-   "mode": "strict",
-   "self_test": null,
-   "self_test_required": false,
-   "must_refuse": [
-    {
-     "vector": "a benchmark 3x slower than its baseline, past the declared threshold",
-     "files": {
-      "current.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 120000\n    }\n  }\n}\n",
-      "baseline.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 38600\n    }\n  },\n  \"threshold_percent\": 15\n}\n"
-     },
-     "accepts": {
-      "current.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 39000\n    }\n  }\n}\n",
-      "baseline.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 38600\n    }\n  },\n  \"threshold_percent\": 15\n}\n"
-     },
-     "argv": [
-      "--current",
-      "{root}/current.json",
-      "--baseline",
-      "{root}/baseline.json",
-      "--threshold",
-      "15"
-     ]
-    }
-   ],
-   "blind_spot": {
-    "issue": null,
-    "summary": "Found by the reverse sweep, not by the name pattern: it exits 1 on a regression and runs in the required perf-smoke job, yet matched no guard-shaped name and was absent from this registry entirely. A benchmark absent from `current` is not compared — an empty result set exits 0 (compare_perf.py:119)."
-   }
-  },
-  {
-   "script": "scripts/check-durability-barrier.py",
-   "purpose": "Every production file calling File::create carries a sync_all barrier or an audited baseline exemption — closes the class behind the sparse-WAL (#1978) and save_config (#1985) power-loss gaps (adversarial review, #1981 item 2).",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "lint",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_durability_barrier",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": null,
-    "summary": "Only File::create is matched (OpenOptions writers are not scanned; today every such production site lives in the WAL helpers, which carry the barrier). Same-file granularity: an unrelated sync_all elsewhere in the file satisfies the check — placement stays review territory. Inline test modules are skipped by truncating at the first #[cfg(test)] mod marker, so a production File::create placed AFTER an inline test module would be missed (none exists; convention keeps test mods last)."
-   },
-   "must_refuse": [
-    {
-     "vector": "a new production file that File::create's with no sync_all and no baseline entry",
-     "argv": [
-      "{root}",
-      "{root}/scripts/durability-barrier-baseline.txt"
-     ],
-     "files": {
-      "crates/velesdb-core/src/new_writer.rs": "pub fn w(p: &std::path::Path) { let _ = std::fs::File::create(p); }\n",
-      "scripts/durability-barrier-baseline.txt": "# empty baseline for the refusal-vector harness\n"
-     },
-     "accepts": {
-      "crates/velesdb-core/src/new_writer.rs": "pub fn w(p: &std::path::Path) -> std::io::Result<()> {\n    let f = std::fs::File::create(p)?;\n    f.sync_all()\n}\n",
-      "scripts/durability-barrier-baseline.txt": "# empty baseline for the refusal-vector harness\n"
-     }
-    }
-   ]
-  },
-  {
-   "script": "scripts/check-drop-tightening.py",
-   "purpose": "Freeze the clippy::significant_drop_tightening backlog per file so it can only shrink, the precondition for promoting the lint to deny alongside significant_drop_in_scrutinee (#2110).",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "drop-tightening-check",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_check_drop_tightening",
-   "self_test_required": true,
-   "blind_spot": {
-    "issue": 2110,
-    "summary": "Covers velesdb-core and velesdb-server only - the crates that build without GTK, so the baseline stays regenerable by anyone. They hold all 326 findings measured on 2026-08-27 (velesdb-core's lib is linted even when only velesdb-server is named, because a workspace path dependency is a primary unit and is not --cap-lints'd), but velesdb-cli, velesdb-memory, velesdb-migrate, velesdb-mobile, velesdb-wasm and tauri-plugin-velesdb are unmeasured and a new site in one of them lands unseen. Widening needs a measured baseline from a machine that can build them, never an estimate. Counts are per file rather than per site, so moving a finding between two baselined files is invisible when the totals offset."
-   },
-   "must_refuse": [
-    {
-     "vector": "a file that gained a finding above its frozen count",
-     "files": {
-      "baseline.txt": "crates/velesdb-core/src/a.rs\t1\n",
-      "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n"
-     },
-     "accepts": {
-      "baseline.txt": "crates/velesdb-core/src/a.rs\t1\n",
-      "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n"
-     },
-     "argv": [
-      "--from-json",
-      "{root}/clippy.json",
-      "--baseline",
-      "{root}/baseline.txt"
-     ]
     },
     {
-     "vector": "a finding in a file the frozen baseline does not list",
-     "files": {
-      "baseline.txt": "crates/velesdb-core/src/a.rs\t1\n",
-      "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/brand_new.rs\",\"is_primary\":true}]}}\n"
-     },
-     "accepts": {
-      "baseline.txt": "crates/velesdb-core/src/a.rs\t1\ncrates/velesdb-core/src/brand_new.rs\t1\n",
-      "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/brand_new.rs\",\"is_primary\":true}]}}\n"
-     },
-     "argv": [
-      "--from-json",
-      "{root}/clippy.json",
-      "--baseline",
-      "{root}/baseline.txt"
-     ]
-    }
-   ]
-  },
-  {
-   "script": "scripts/npm-audit-gate.py",
-   "purpose": "No npm lockfile carries a high or critical advisory — and a registry that never answered is reported as infrastructure (exit 75), never as a finding.",
-   "workflow": ".github/workflows/gate-contracts.yml",
-   "job": "npm-audit",
-   "required": true,
-   "mode": "strict",
-   "self_test": "scripts.tests.test_npm_audit_gate",
-   "self_test_required": true,
-   "must_refuse": [
-    {
-     "vector": "a lockfile with a high advisory — against an npm that exits 1 in BOTH states, so the accepted control proves the gate reads the report and not the exit code that conflated the two",
-     "files": {
-      "package-lock.json": "{\n  \"lockfileVersion\": 3\n}\n",
-      "tools/fake-npm": "#!/usr/bin/env python3\nimport sys\nsys.stdout.write('{\"auditReportVersion\": 2, \"vulnerabilities\": {}, \"metadata\": {\"vulnerabilities\": {\"info\": 0, \"low\": 0, \"moderate\": 0, \"high\": 1, \"critical\": 0, \"total\": 1}}}')\nraise SystemExit(1)\n"
-     },
-     "accepts": {
-      "package-lock.json": "{\n  \"lockfileVersion\": 3\n}\n",
-      "tools/fake-npm": "#!/usr/bin/env python3\nimport sys\nsys.stdout.write('{\"auditReportVersion\": 2, \"vulnerabilities\": {}, \"metadata\": {\"vulnerabilities\": {\"info\": 0, \"low\": 0, \"moderate\": 0, \"high\": 0, \"critical\": 0, \"total\": 0}}}')\nraise SystemExit(1)\n"
-     },
-     "executable": {
-      "files": [
-       "tools/fake-npm"
-      ],
-      "accepts": [
-       "tools/fake-npm"
+      "script": "scripts/check-feature-claims.py",
+      "purpose": "Documented feature claims match real exports.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_feature_claims",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Breaks (reports column_store MISSING) if any string literal in velesdb-python/src uses a backslash line-continuation."
+      },
+      "must_refuse": [
+        {
+          "vector": "a roadmap entry still marked in-progress, which the audit must not let a README present as shipped",
+          "files": {
+            "ROADMAP.md": "## EPIC-010 Agent Memory SDK — in progress\n"
+          },
+          "accepts": {
+            "ROADMAP.md": "## EPIC-010 Agent Memory SDK — delivered\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
       ]
-     },
-     "argv": [
-      "--root",
-      "{root}",
-      "--npm",
-      "{root}/tools/fake-npm",
-      "--attempts",
-      "1",
-      "--backoff-seconds",
-      "0"
-     ]
+    },
+    {
+      "script": "scripts/check-perf-claims.py",
+      "purpose": "Performance numbers stay consistent across documents.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_perf_claims",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Can reach exit 1 again (#1701 closed): the grouping key no longer contains its own value, so two documents claiming different numbers for one benchmark collide and are compared. Measured limit, not a defect: this repository's corpus yields ZERO comparable groups, so a green run here says nothing about the guard — which is exactly why its refusal is proven below on a corpus of its own. The Criterion front stays out of the exit code by design."
+      },
+      "must_refuse": [
+        {
+          "vector": "two documents claiming 38.6 us and 120.0 us for the same benchmark",
+          "files": {
+            "README.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 38.6 µs |\n",
+            "docs/BENCHMARKS.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 120.0 µs |\n"
+          },
+          "accepts": {
+            "README.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 38.6 µs |\n",
+            "docs/BENCHMARKS.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 39.0 µs |\n"
+          },
+          "argv": [
+            "--no-criterion",
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/check-mcp-doc-contract.py",
+      "purpose": "Documented MCP return shapes match the published outputSchema.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "mcp-doc-contract",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_mcp_doc_contract",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the shipped MCP registry with feedback's documented confidence key renamed, against the untouched tracked repository",
+          "base": "repository",
+          "files": {},
+          "accepts": {},
+          "replace": {
+            "files": [
+              {
+                "path": "docs/reference/MCP_TOOLS.md",
+                "old": "Returns `{ id, id_str, confidence }`",
+                "new": "Returns `{ id, id_str, certainty }`"
+              }
+            ],
+            "accepts": []
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "batch 2: compile_context loses one published root field on the editable source skill",
+          "base": "repository",
+          "files": {},
+          "accepts": {},
+          "replace": {
+            "files": [
+              {
+                "path": "skills/velesdb-context-optimizer/SKILL.md",
+                "old": "`compile_context` returns `{content, sections, decisions, sources,\nretrieval_handles, insights, risk, warnings}`.",
+                "new": "`compile_context` returns `{content, sections, decisions, sources,\nretrieval_handles, insights, risk}`."
+              }
+            ],
+            "accepts": []
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "batch 3: remember_extracted renames a field in its durable background-job receipt",
+          "base": "repository",
+          "files": {},
+          "accepts": {},
+          "replace": {
+            "files": [
+              {
+                "path": "crates/velesdb-memory/skill/velesdb-memory/SKILL.md",
+                "old": "returns `{request_id, state, reused}` before model generation.",
+                "new": "returns `{request_id, state, accepted}` before model generation."
+              }
+            ],
+            "accepts": []
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ],
+      "subguards": [
+        "return-shape"
+      ]
+    },
+    {
+      "script": "scripts/check-skill-private-references.py",
+      "purpose": "No versioned skill points at something only the private repository holds.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "mcp-doc-contract",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_skill_private_references",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "a versioned skill sending the reader to a standard held in the closed repository",
+          "files": {
+            "skills/demo/SKILL.md": "# Demo\n\nBefore declaring premium coverage done, cross-check the axes.\n"
+          },
+          "accepts": {
+            "skills/demo/SKILL.md": "# Demo\n\nBefore declaring coverage done, cross-check the axes.\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "the bundled npm copy naming the private repository — that copy is the one that leaves the machine",
+          "files": {
+            "crates/velesdb-node/skills/demo/SKILL.md": "# Demo\n\nSee velesdb-private for the enforcing policy.\n"
+          },
+          "accepts": {
+            "crates/velesdb-node/skills/demo/SKILL.md": "# Demo\n\nSee the architecture reference for the boundary.\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a tree holding no versioned skill at all — deleting skills/ is the cheapest way to retire this guard while leaving it in the workflow",
+          "files": {
+            "docs/README.md": "nothing to scan here\n"
+          },
+          "accepts": {
+            "docs/README.md": "nothing to scan here\n",
+            "skills/demo/SKILL.md": "# Demo\n\nUse recall before proposing an approach.\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "Reads the two declared markers and nothing else. It does NOT catch a bare issue or pull-request number belonging to the closed repository: the learning-loop skill arrived citing one three times, and no property of the text separates it from the public `#1455` and `#1473` two other skills cite usefully — a guess would either block those or catch nothing. That half was closed by rewriting the passages, not by this guard. Scope is the skill directories only, by design: docs/CORE_PREMIUM_SPLIT.md documents the split on purpose."
+      }
+    },
+    {
+      "script": "scripts/check-doc-contract.sh",
+      "purpose": "Every runtime route of the server is documented in the root README.",
+      "workflow": ".github/workflows/doc-contract.yml",
+      "job": "contract",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": null,
+        "summary": "None known. #1707 is closed: the four routes (/collections/{name}/compact, points/raw, stream/enable, vacuum) are now documented in README.md, and DOC_CONTRACT_MODE's default flipped to strict in the same commit, so a full-sweep finding fails the build like the pinned routes always did."
+      },
+      "must_refuse": [
+        {
+          "vector": "a route added under the server crate without a matching README backtick entry — the four-route gap of #1707",
+          "files": {
+            "crates/velesdb-server/src/routes.rs": "pub fn build_router() {\n    Router::new()\n        .route(\"/query/explain\", post(explain))\n        .route(\"/aggregate\", post(aggregate))\n        .route(\"/collections/{name}/vacuum\", post(vacuum_collection));\n}\n",
+            "README.md": "# Test fixture\n\nAPI: `/query/explain`, `/aggregate`\n"
+          },
+          "accepts": {
+            "crates/velesdb-server/src/routes.rs": "pub fn build_router() {\n    Router::new()\n        .route(\"/query/explain\", post(explain))\n        .route(\"/aggregate\", post(aggregate))\n        .route(\"/collections/{name}/vacuum\", post(vacuum_collection));\n}\n",
+            "README.md": "# Test fixture\n\nAPI: `/query/explain`, `/aggregate`, `/collections/{name}/vacuum`\n"
+          },
+          "argv": []
+        }
+      ],
+      "required_via": "doc-contract"
+    },
+    {
+      "script": "scripts/check-doc-freshness.py",
+      "purpose": "Doc stamps, index, declarative and prose version references, the tracked-contract rule and the decisions index stay honest (five guards).",
+      "workflow": ".github/workflows/doc-contract.yml",
+      "job": "freshness",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_doc_freshness",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "None known. The `index` guard ran in warn mode over eleven root docs a comment called unreachable; measured, all eleven are linked and strict exits 0, so the comment had kept a working guard disarmed. All five guards are strict from here. `tracked` reads git, not the filesystem: a path that exists and a path a clone receives are not the same path. `decisions` sweeps docs/decisions/ only, non-recursively: a subdirectory is another index's business. Three limits it does not reach: docs/decisions/README.md is itself required by nothing, since `index` only sweeps the root of docs/; an index listing nothing, in a directory holding only that index, passes vacuously; and a listed file that exists but is untracked is `tracked`'s jurisdiction, not this one's."
+      },
+      "required_via": "doc-contract",
+      "must_refuse": [
+        {
+          "vector": "a current onboarding page naming packages from an older released VelesDB version in prose",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"5.0.0\"\n",
+            "crates/velesdb-memory/Cargo.toml": "[package]\nname = \"velesdb-memory\"\nversion = \"0.12.0\"\n",
+            "docs/getting-started.md": "# Getting started\n\nTimed against the published v4.3.0 packages.\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"5.0.0\"\n",
+            "crates/velesdb-memory/Cargo.toml": "[package]\nname = \"velesdb-memory\"\nversion = \"0.12.0\"\n",
+            "docs/getting-started.md": "# Getting started\n\nTimed against the published v5.0.0 packages.\n"
+          },
+          "argv": [
+            "--guard",
+            "versions",
+            "--mode",
+            "strict",
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "an entry document designating a file that exists but is NOT tracked — the shape that hid CLAUDE.md, AGENTS.md and CORE_PREMIUM_SPLIT.md behind .git/info/exclude",
+          "files": {
+            "AGENTS.md": "# Entry\n\nRead the [boundary contract](docs/BOUNDARY.md) before any change.\n",
+            "docs/BOUNDARY.md": "# Boundary\n\nvelesdb-core must never reference any premium crate.\n"
+          },
+          "accepts": {
+            "AGENTS.md": "# Entry\n\nRead the [boundary contract](docs/BOUNDARY.md) before any change.\n",
+            "docs/BOUNDARY.md": "# Boundary\n\nvelesdb-core must never reference any premium crate.\n"
+          },
+          "repo": {
+            "files": [
+              "AGENTS.md"
+            ],
+            "accepts": [
+              "AGENTS.md",
+              "docs/BOUNDARY.md"
+            ]
+          },
+          "argv": [
+            "--guard",
+            "tracked",
+            "--mode",
+            "strict",
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a decision file present in docs/decisions/ that the index does not list — the orphan `index` cannot see, because it only sweeps the root of docs/",
+          "files": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
+            "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
+          },
+          "accepts": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
+            "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
+          },
+          "argv": [
+            "--guard",
+            "decisions",
+            "--mode",
+            "strict",
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "the decisions index listing a file that does not exist — the dead link `index` structurally cannot catch, since it only checks doc-to-index and never index-to-doc",
+          "files": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n"
+          },
+          "accepts": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
+            "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
+          },
+          "argv": [
+            "--guard",
+            "decisions",
+            "--mode",
+            "strict",
+            "--root",
+            "{root}"
+          ]
+        }
+      ],
+      "subguards": [
+        "stamp",
+        "index",
+        "versions",
+        "tracked",
+        "decisions"
+      ]
+    },
+    {
+      "script": "scripts/check-promise-contract.py",
+      "purpose": "The promise-contract registry stays valid.",
+      "workflow": ".github/workflows/promise-contract.yml",
+      "job": "contract",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_promise_contract",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `promise-contract` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "promise-contract",
+      "must_refuse": [
+        {
+          "vector": "a capacity-mode doc promising sq8 buys search throughput — the overclaim Requirement 10.4 exists to refuse",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "an .mcpb recommendation pointing at the repository-wide latest release instead of the independent memory release train",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "README.md": "Get the `.mcpb` bundle from https://github.com/cyberlife-coder/VelesDB/releases/latest.\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "README.md": "Get the `.mcpb` bundle from https://registry.modelcontextprotocol.io/.\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ],\n  \"claim_families\": [\n    {\n      \"id\": \"quantization_heading\",\n      \"canonical_claim_id\": \"quantization-is-documented\",\n      \"canonical_value\": \"Quantization\",\n      \"members\": [\n        {\n          \"file\": \"docs/guides/QUANTIZATION.md\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"# Quantization\"\n        },\n        {\n          \"file\": \"crates/velesdb-core/src/quantization/mod.rs\",\n          \"value\": \"Quantization\",\n          \"must_contain\": \"//! Quantization.\"\n        }\n      ]\n    }\n  ]\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/check-python.sh",
+      "purpose": "Python integration checks (dangerous hash(), non-determinism, bandit, flake8 complexity).",
+      "workflow": ".github/workflows/propagation-guard.yml",
+      "job": "integrations-python",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Entirely cwd-relative (PYTHON_DIRS) with no --root and no cd of its own: run from a subdirectory it scans nothing and exits 0 — measured from docs/. Harmless in CI, which runs it from the root, and it is what lets the refusal harness drive it with an empty argv. Only checks 1, 3 and 4 can raise ERRORS; 2 and 5 warn and can never refuse."
+      },
+      "required_via": "propagation-guard",
+      "must_refuse": [
+        {
+          "vector": "a builtin hash() used to derive a token — non-deterministic across processes, which is the whole point of check 1",
+          "files": {
+            "integrations/langchain/src/velesdb_langchain/store.py": "def token_for(doc):\n    return hash(doc)\n"
+          },
+          "accepts": {
+            "integrations/langchain/src/velesdb_langchain/store.py": "import hashlib\n\n\ndef token_for(doc):\n    return hashlib.sha256(doc).hexdigest()\n"
+          },
+          "argv": []
+        }
+      ]
+    },
+    {
+      "script": "scripts/check_binary_size.py",
+      "purpose": "Release binaries stay within their size ceilings.",
+      "workflow": ".github/workflows/binary-size.yml",
+      "job": "binary-size",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_binary_size",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Measures the apparent size of three binaries on the CI runner's target only (linux x86_64): the macOS and Windows release artifacts and the wasm bundle are outside its reach, as is any growth that stays under a ceiling. This field previously claimed the OVER-CEILING half was not vector-testable (a fixture exceeding a ceiling would mean carrying 9 MiB of literal bytes in this registry) and that it was exercised for real on every release. Both were false. The guard reads st_size, so a sparse fixture exceeds any ceiling for free - scripts.tests.test_check_binary_size now covers that half, including the boundary and a silently-raised ceiling. And the release build did produce over-ceiling binaries: binary-size.yml piped the guard into tee under a shell without pipefail, so the job took tee's exit status and reported success while the guard printed FAILED (#2193). The half declared exercised for real was the only half that could never turn a build red."
+      },
+      "required_via": "binary-size",
+      "must_refuse": [
+        {
+          "vector": "a release that built only two of its three binaries — the gate must not pass on a binary it never weighed",
+          "files": {
+            "velesdb-server": "stub\n",
+            "velesdb": "stub\n"
+          },
+          "accepts": {
+            "velesdb-server": "stub\n",
+            "velesdb": "stub\n",
+            "velesdb-migrate": "stub\n"
+          },
+          "argv": [
+            "--target-dir",
+            "{root}"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/run-production-gates.sh",
+      "purpose": "Meta-runner chaining the production gates.",
+      "workflow": ".github/workflows/production-gates.yml",
+      "job": "gates",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_run_production_gates",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "production-gates",
+      "subguards": [
+        "doc-contract",
+        "promise-contract",
+        "planner",
+        "crash-recovery",
+        "wal-recovery"
+      ],
+      "must_refuse": [
+        {
+          "vector": "the production meta-runner's doc-contract member sees a runtime route missing from README, then accepts the documented route",
+          "files": {
+            "crates/velesdb-server/src/routes.rs": ".route(\"/query/explain\", get(explain))\n.route(\"/aggregate\", post(aggregate))\n",
+            "README.md": "`/query/explain`\n"
+          },
+          "accepts": {
+            "crates/velesdb-server/src/routes.rs": ".route(\"/query/explain\", get(explain))\n.route(\"/aggregate\", post(aggregate))\n",
+            "README.md": "`/query/explain`\n`/aggregate`\n"
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--guard",
+            "doc-contract"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/check-pr-governance.py",
+      "purpose": "Git Flow source/target rules and freshness of the branch against its fetched base.",
+      "workflow": ".github/workflows/pr-governance.yml",
+      "job": "governance",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_pr_governance",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "an archived PR source is refused while an admitted feature source targeting develop passes",
+          "files": {
+            "EVENT.txt": "pull request policy fixture\n"
+          },
+          "accepts": {
+            "EVENT.txt": "pull request policy fixture\n"
+          },
+          "argv": {
+            "files": [
+              "--guard",
+              "git-flow",
+              "--source-ref",
+              "archive/old-work",
+              "--base-ref",
+              "develop"
+            ],
+            "accepts": [
+              "--guard",
+              "git-flow",
+              "--source-ref",
+              "feat/current-work",
+              "--base-ref",
+              "develop"
+            ]
+          }
+        },
+        {
+          "vector": "a fetched base on a sibling commit is refused while the same base as an ancestor of HEAD passes",
+          "files": {
+            "TRACKED.txt": "branch topology fixture\n"
+          },
+          "accepts": {
+            "TRACKED.txt": "branch topology fixture\n"
+          },
+          "repo": {
+            "files": [
+              "TRACKED.txt"
+            ],
+            "accepts": [
+              "TRACKED.txt"
+            ],
+            "relation": {
+              "files": "diverged",
+              "accepts": "ancestor"
+            }
+          },
+          "argv": [
+            "--guard",
+            "freshness",
+            "--root",
+            "{root}",
+            "--base-ref",
+            "develop",
+            "--base-commit",
+            "refs/heads/vector-base"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "The GitHub event-to-CLI mapping remains YAML's responsibility. The wiring contract pins both explicit --guard selectors; unit tests and vectors cover the policy and real git topology after that boundary. AI attribution is a separate executable guard in the same job."
+      },
+      "required_via": "pr-governance",
+      "subguards": [
+        "git-flow",
+        "freshness"
+      ]
+    },
+    {
+      "script": "scripts/check-ai-attribution.py",
+      "purpose": "No commit is authored by, or attributed to, an AI assistant (CLAUDE.md #5).",
+      "workflow": ".github/workflows/pr-governance.yml",
+      "job": "governance",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_ai_attribution",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "a commit whose author identity is an assistant, against the same tree authored by a person whose name merely starts the same way",
+          "files": {
+            "NOTES.md": "placeholder\n"
+          },
+          "accepts": {
+            "NOTES.md": "placeholder\n"
+          },
+          "repo": {
+            "files": [
+              "NOTES.md"
+            ],
+            "accepts": [
+              "NOTES.md"
+            ],
+            "author": {
+              "files": "Claude <claude@anthropic.com>",
+              "accepts": "Claudette <claudette@example.com>"
+            }
+          },
+          "argv": [
+            "HEAD",
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a pull request body carrying the attribution footer tooling appends on publish",
+          "files": {
+            "pr-body.md": "## Description\n\nA real change.\n\n---\n_Generated by [Claude Code](https://claude.ai/code)_\n"
+          },
+          "accepts": {
+            "pr-body.md": "## Description\n\nA real change.\n"
+          },
+          "argv": [
+            "--text",
+            "{root}/pr-body.md",
+            "--surface",
+            "pull request body"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "Reads the RAW identity (%an <%ae>, never %aN): a .mailmap line in this repository already maps anthropic to the maintainer, and the mapped name would launder the case being looked for. Admission is by whole identity, so an impostor of an admitted bot does not inherit it. --text covers the pull request title and description and --tree covers tracked repository content, but NOT issue or PR comments: no workflow trigger delivers a comment body to this guard today, so a footer pasted into a comment is still caught only by review. Title and body are read from the event payload, and ci.yml skips an 'edited' event that does not change the base (the #22 fix that stopped no-op edits cancelling real runs), so a footer added by EDITING a description after the run is not re-checked; creation, pushes and reopens are. --tree strips a comment or blockquote leader before applying the rule, which the commit-message path deliberately does not, so a source line quoting a trailer behind // or # is refused there and accepted in a commit message describing it. --tree has no must_refuse vector: the harness materialises a refusal by copying the tracked tree (base: repository), and a mode that then reads every file in that copy exhausts the runner. Its refusal is covered by unit tests instead, including a positive control that the checked-in tree passes. Its URL pattern is also unanchored, unlike the trailer patterns, so a body that quotes the footer verbatim in order to DESCRIBE the rule is refused along with one that carries it; write the URL in parts when documenting it, as this repo's own tests do."
+      },
+      "required_via": "pr-governance"
+    },
+    {
+      "script": "scripts/run-node-binding-tests.py",
+      "purpose": "The Node binding's functional gate: build the napi addon (debug profile) and run every __test__/*.spec.mjs suite via `npm test`.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "node-binding-tests",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_ci_test_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the Linux N-API pipeline reaches a failing npm test after install and build, then propagates a repaired tool's success",
+          "files": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1 if sys.argv[1:] == ['test'] else 0)\n"
+          },
+          "accepts": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-ci-tool"
+            ],
+            "accepts": [
+              "tools/fake-ci-tool"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--npm",
+            "{root}/tools/fake-ci-tool",
+            "--npx",
+            "{root}/tools/fake-ci-tool"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "The vector dependency-injects npm/npx to prove the exact three-stage sequence and exit propagation without compiling the addon twice. The required CI job still supplies the real tools and crate; the Node suites own addon semantics."
+      }
+    },
+    {
+      "script": "scripts/run-node-binding-tests-windows.py",
+      "purpose": "The Windows leg of the Node binding gate (#1515): the same napi build, then `node --test __test__/index.spec.mjs` — the file that carries the three Windows-only regressions (#1509, #1510, #1511).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "node-binding-tests-windows",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_ci_test_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the Windows N-API pipeline reaches a failing explicit Node spec after install and build, then propagates success",
+          "files": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1 if sys.argv[1:2] == ['--test'] else 0)\n"
+          },
+          "accepts": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-ci-tool"
+            ],
+            "accepts": [
+              "tools/fake-ci-tool"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--npm",
+            "{root}/tools/fake-ci-tool",
+            "--npx",
+            "{root}/tools/fake-ci-tool",
+            "--node",
+            "{root}/tools/fake-ci-tool"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "The job remains path-filtered by node-windows-changed, so PRs outside crates/velesdb-node intentionally no-op. The command contract pins the Windows-specific explicit spec; the vector substitutes tools only to make its refusal hermetic."
+      }
+    },
+    {
+      "script": "scripts/run-wasm-bindgen-tests.py",
+      "purpose": "The WASM functional gate: `wasm-pack test --node crates/velesdb-wasm` runs the wasm-bindgen suites (tests/*.rs gated on target_arch = \"wasm32\") that compile to empty binaries under the native test job and are invisible to `cargo check`.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "wasm-check",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_ci_test_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the wasm-bindgen Node runner propagates wasm-pack's refusal and accepts the repaired tool",
+          "files": {
+            "crates/velesdb-wasm/.fixture": "crate root\n",
+            "tools/fake-wasm-pack": "#!/usr/bin/env python3\nraise SystemExit(1)\n"
+          },
+          "accepts": {
+            "crates/velesdb-wasm/.fixture": "crate root\n",
+            "tools/fake-wasm-pack": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-wasm-pack"
+            ],
+            "accepts": [
+              "tools/fake-wasm-pack"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--wasm-pack",
+            "{root}/tools/fake-wasm-pack"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "The vector substitutes wasm-pack to prove command shape and refusal propagation without installing the wasm toolchain in gate-contracts. The required wasm-check job supplies real wasm-pack and owns wasm32 suite semantics."
+      }
+    },
+    {
+      "script": "scripts/compare_perf.py",
+      "purpose": "A benchmark that regresses past its threshold fails the build (perf-smoke).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "perf-smoke",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "must_refuse": [
+        {
+          "vector": "a benchmark 3x slower than its baseline, past the declared threshold",
+          "files": {
+            "current.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 120000\n    }\n  }\n}\n",
+            "baseline.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 38600\n    }\n  },\n  \"threshold_percent\": 15\n}\n"
+          },
+          "accepts": {
+            "current.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 39000\n    }\n  }\n}\n",
+            "baseline.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 38600\n    }\n  },\n  \"threshold_percent\": 15\n}\n"
+          },
+          "argv": [
+            "--current",
+            "{root}/current.json",
+            "--baseline",
+            "{root}/baseline.json",
+            "--threshold",
+            "15"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "Found by the reverse sweep, not by the name pattern: it exits 1 on a regression and runs in the required perf-smoke job, yet matched no guard-shaped name and was absent from this registry entirely. A benchmark absent from `current` is not compared — an empty result set exits 0 (compare_perf.py:119)."
+      }
+    },
+    {
+      "script": "scripts/check-durability-barrier.py",
+      "purpose": "Every production file calling File::create carries a sync_all barrier or an audited baseline exemption — closes the class behind the sparse-WAL (#1978) and save_config (#1985) power-loss gaps (adversarial review, #1981 item 2).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_durability_barrier",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Only File::create is matched (OpenOptions writers are not scanned; today every such production site lives in the WAL helpers, which carry the barrier). Same-file granularity: an unrelated sync_all elsewhere in the file satisfies the check — placement stays review territory. Inline test modules are skipped by truncating at the first #[cfg(test)] mod marker, so a production File::create placed AFTER an inline test module would be missed (none exists; convention keeps test mods last)."
+      },
+      "must_refuse": [
+        {
+          "vector": "a new production file that File::create's with no sync_all and no baseline entry",
+          "argv": [
+            "{root}",
+            "{root}/scripts/durability-barrier-baseline.txt"
+          ],
+          "files": {
+            "crates/velesdb-core/src/new_writer.rs": "pub fn w(p: &std::path::Path) { let _ = std::fs::File::create(p); }\n",
+            "scripts/durability-barrier-baseline.txt": "# empty baseline for the refusal-vector harness\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/new_writer.rs": "pub fn w(p: &std::path::Path) -> std::io::Result<()> {\n    let f = std::fs::File::create(p)?;\n    f.sync_all()\n}\n",
+            "scripts/durability-barrier-baseline.txt": "# empty baseline for the refusal-vector harness\n"
+          }
+        }
+      ]
+    },
+    {
+      "script": "scripts/check-drop-tightening.py",
+      "purpose": "Freeze the clippy::significant_drop_tightening backlog per file so it can only shrink, the precondition for promoting the lint to deny alongside significant_drop_in_scrutinee (#2110).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "drop-tightening-check",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_drop_tightening",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": 2110,
+        "summary": "Covers velesdb-core and velesdb-server only - the crates that build without GTK, so the baseline stays regenerable by anyone. They hold all 326 findings measured on 2026-08-27 (velesdb-core's lib is linted even when only velesdb-server is named, because a workspace path dependency is a primary unit and is not --cap-lints'd), but velesdb-cli, velesdb-memory, velesdb-migrate, velesdb-mobile, velesdb-wasm and tauri-plugin-velesdb are unmeasured and a new site in one of them lands unseen. Widening needs a measured baseline from a machine that can build them, never an estimate. Counts are per file rather than per site, so moving a finding between two baselined files is invisible when the totals offset."
+      },
+      "must_refuse": [
+        {
+          "vector": "a file that gained a finding above its frozen count",
+          "files": {
+            "baseline.txt": "crates/velesdb-core/src/a.rs\t1\n",
+            "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n"
+          },
+          "accepts": {
+            "baseline.txt": "crates/velesdb-core/src/a.rs\t1\n",
+            "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n"
+          },
+          "argv": [
+            "--from-json",
+            "{root}/clippy.json",
+            "--baseline",
+            "{root}/baseline.txt"
+          ]
+        },
+        {
+          "vector": "a finding in a file the frozen baseline does not list",
+          "files": {
+            "baseline.txt": "crates/velesdb-core/src/a.rs\t1\n",
+            "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/brand_new.rs\",\"is_primary\":true}]}}\n"
+          },
+          "accepts": {
+            "baseline.txt": "crates/velesdb-core/src/a.rs\t1\ncrates/velesdb-core/src/brand_new.rs\t1\n",
+            "clippy.json": "{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/a.rs\",\"is_primary\":true}]}}\n{\"reason\":\"compiler-message\",\"message\":{\"code\":{\"code\":\"clippy::significant_drop_tightening\"},\"level\":\"warning\",\"spans\":[{\"file_name\":\"crates/velesdb-core/src/brand_new.rs\",\"is_primary\":true}]}}\n"
+          },
+          "argv": [
+            "--from-json",
+            "{root}/clippy.json",
+            "--baseline",
+            "{root}/baseline.txt"
+          ]
+        }
+      ]
+    },
+    {
+      "script": "scripts/npm-audit-gate.py",
+      "purpose": "No npm lockfile carries a high or critical advisory — and a registry that never answered is reported as infrastructure (exit 75), never as a finding.",
+      "workflow": ".github/workflows/gate-contracts.yml",
+      "job": "npm-audit",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_npm_audit_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "a lockfile with a high advisory — against an npm that exits 1 in BOTH states, so the accepted control proves the gate reads the report and not the exit code that conflated the two",
+          "files": {
+            "package-lock.json": "{\n  \"lockfileVersion\": 3\n}\n",
+            "tools/fake-npm": "#!/usr/bin/env python3\nimport sys\nsys.stdout.write('{\"auditReportVersion\": 2, \"vulnerabilities\": {}, \"metadata\": {\"vulnerabilities\": {\"info\": 0, \"low\": 0, \"moderate\": 0, \"high\": 1, \"critical\": 0, \"total\": 1}}}')\nraise SystemExit(1)\n"
+          },
+          "accepts": {
+            "package-lock.json": "{\n  \"lockfileVersion\": 3\n}\n",
+            "tools/fake-npm": "#!/usr/bin/env python3\nimport sys\nsys.stdout.write('{\"auditReportVersion\": 2, \"vulnerabilities\": {}, \"metadata\": {\"vulnerabilities\": {\"info\": 0, \"low\": 0, \"moderate\": 0, \"high\": 0, \"critical\": 0, \"total\": 0}}}')\nraise SystemExit(1)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-npm"
+            ],
+            "accepts": [
+              "tools/fake-npm"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--npm",
+            "{root}/tools/fake-npm",
+            "--attempts",
+            "1",
+            "--backoff-seconds",
+            "0"
+          ]
+        }
+      ],
+      "required_via": "gate-contracts",
+      "blind_spot": {
+        "issue": null,
+        "summary": "The vector injects an npm double, so it pins the classification and both exit codes but not npm's own report schema; an npm that renamed `metadata.vulnerabilities` would read as unreachable (exit 75, job red) rather than as silently clean — the safe direction. The unreachable branch exits 75 and so cannot be a refusal vector, which this harness defines as exit 1; scripts.tests.test_npm_audit_gate covers it end to end instead, including a hung npm cut off by --attempt-timeout."
+      }
+    },
+    {
+      "script": "scripts/check-deferred-removals.py",
+      "purpose": "A removal promised for a future major has not been skipped by that major (#2174).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_deferred_removals",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "The registry it reads is a list inside the guard, so deleting an entry disarms that entry. The refusal vectors below close it for the entry that exists: emptying DEFERRED_REMOVALS stops the v7 tree being refused and fails this file's own contract. A FUTURE entry added without its own vector would still be silently deletable, which is why an entry and a vector are added together."
+      },
+      "must_refuse": [
+        {
+          "vector": "the promised major arrived and the removal did not happen — the v6.0.0 miss of #2174",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"7.0.0\"\n",
+            "crates/velesdb-core/src/config.rs": "pub struct WalBatchConfig {}\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"7.0.0\"\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a dependency table above [workspace.package] must not be read as the workspace version",
+          "files": {
+            "Cargo.toml": "[workspace]\n[workspace.dependencies.some-crate]\nversion = \"1.2.3\"\n[workspace.package]\nversion = \"7.0.0\"\n",
+            "crates/velesdb-core/src/config.rs": "pub struct WalBatchConfig {}\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace]\n[workspace.dependencies.some-crate]\nversion = \"1.2.3\"\n[workspace.package]\nversion = \"6.0.0\"\n",
+            "crates/velesdb-core/src/config.rs": "pub struct WalBatchConfig {}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
     }
-   ],
-   "required_via": "gate-contracts",
-   "blind_spot": {
-    "issue": null,
-    "summary": "The vector injects an npm double, so it pins the classification and both exit codes but not npm's own report schema; an npm that renamed `metadata.vulnerabilities` would read as unreachable (exit 75, job red) rather than as silently clean — the safe direction. The unreachable branch exits 75 and so cannot be a refusal vector, which this harness defines as exit 1; scripts.tests.test_npm_audit_gate covers it end to end instead, including a hung npm cut off by --attempt-timeout."
-   }
-  }
- ],
- "unwired": [
-  {
-   "script": "scripts/changelog-release-notes.py",
-   "reason": "Release-time only, by design: release-memory.yml runs it to turn the crate CHANGELOG section into the GitHub Release body, and it refuses (exit 1) a real release whose version the CHANGELOG does not document. A pull request has no release to write notes for; scripts.tests.test_changelog_release_notes proves the refusals, the exact-version match, the terminal-section case and the workflow wiring.",
-   "issue": null
-  },
-  {
-   "script": "scripts/create-release-tag.sh",
-   "reason": "Release-time only, by design: tag-release.yml runs it to guard an operator-requested tag on either release train (vX.Y.Z off main, velesdb-memory-vX.Y.Z off develop) after that branch's CI is green. A pull request has no release tag to assert; scripts.tests.test_create_release_tag proves every refusal guard and both positive controls against a real bare remote.",
-   "issue": null
-  },
-  {
-   "script": "scripts/check-crates-io-versions.sh",
-   "reason": "Release-time only, by design: it checks a version collision on crates.io before publishing (release.yml:345, release-memory.yml:187). There is nothing for it to assert on a pull request.",
-   "issue": null
-  },
-  {
-   "script": "scripts/perf_phase_gate.py",
-   "reason": "Invoked by no workflow. QUALITY_BAR.md:220 and docs/contributing/BENCHMARKING_GUIDE.md:274-289 describe it as if it were active, which is the defect: either wire it or say in both documents that it is a manual tool.",
-   "issue": 1708
-  },
-  {
-   "script": "scripts/bump_version.py",
-   "reason": "Release-time only, by design: release.yml:124 runs it to rewrite the version stamps before publishing. There is nothing for it to assert on a pull request. Same class as check-crates-io-versions.sh.",
-   "issue": null
-  }
- ],
- "not_a_gate": [
-  {
-   "script": "scripts/export_smoke_criterion.py",
-   "workflow": ".github/workflows/ci.yml",
-   "job": "perf-smoke",
-   "reason": "Produces the artefact compare_perf.py then judges (ci.yml:1108, one step before). It has no non-zero exit path at all — measured — so it cannot refuse anything, and declaring it a guard would overstate the registry. The claim is checked: the suite reads its source and fails this entry if a failure path ever appears."
-  },
-  {
-   "script": "scripts/bench-memory-extraction.py",
-   "workflow": ".github/workflows/github-models-probe.yml",
-   "job": "probe",
-   "reason": "A measurement harness, not a gate: manual-dispatch probe for #1944 whose exit 1 means 'a case scored fatal' - a result to record, which is why the workflow runs it with `|| true` and fails only on a missing result file. It refuses nothing on any merge path and sits outside CI Success by design."
-  }
- ]
+  ],
+  "unwired": [
+    {
+      "script": "scripts/changelog-release-notes.py",
+      "reason": "Release-time only, by design: release-memory.yml runs it to turn the crate CHANGELOG section into the GitHub Release body, and it refuses (exit 1) a real release whose version the CHANGELOG does not document. A pull request has no release to write notes for; scripts.tests.test_changelog_release_notes proves the refusals, the exact-version match, the terminal-section case and the workflow wiring.",
+      "issue": null
+    },
+    {
+      "script": "scripts/create-release-tag.sh",
+      "reason": "Release-time only, by design: tag-release.yml runs it to guard an operator-requested tag on either release train (vX.Y.Z off main, velesdb-memory-vX.Y.Z off develop) after that branch's CI is green. A pull request has no release tag to assert; scripts.tests.test_create_release_tag proves every refusal guard and both positive controls against a real bare remote.",
+      "issue": null
+    },
+    {
+      "script": "scripts/check-crates-io-versions.sh",
+      "reason": "Release-time only, by design: it checks a version collision on crates.io before publishing (release.yml:345, release-memory.yml:187). There is nothing for it to assert on a pull request.",
+      "issue": null
+    },
+    {
+      "script": "scripts/perf_phase_gate.py",
+      "reason": "Invoked by no workflow. QUALITY_BAR.md:220 and docs/contributing/BENCHMARKING_GUIDE.md:274-289 describe it as if it were active, which is the defect: either wire it or say in both documents that it is a manual tool.",
+      "issue": 1708
+    },
+    {
+      "script": "scripts/bump_version.py",
+      "reason": "Release-time only, by design: release.yml:124 runs it to rewrite the version stamps before publishing. There is nothing for it to assert on a pull request. Same class as check-crates-io-versions.sh.",
+      "issue": null
+    }
+  ],
+  "not_a_gate": [
+    {
+      "script": "scripts/export_smoke_criterion.py",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "perf-smoke",
+      "reason": "Produces the artefact compare_perf.py then judges (ci.yml:1108, one step before). It has no non-zero exit path at all — measured — so it cannot refuse anything, and declaring it a guard would overstate the registry. The claim is checked: the suite reads its source and fails this entry if a failure path ever appears."
+    },
+    {
+      "script": "scripts/bench-memory-extraction.py",
+      "workflow": ".github/workflows/github-models-probe.yml",
+      "job": "probe",
+      "reason": "A measurement harness, not a gate: manual-dispatch probe for #1944 whose exit 1 means 'a case scored fatal' - a result to record, which is why the workflow runs it with `|| true` and fails only on a missing result file. It refuses nothing on any merge path and sits outside CI Success by design."
+    }
+  ]
 }

--- a/scripts/tests/test_check_deferred_removals.py
+++ b/scripts/tests/test_check_deferred_removals.py
@@ -1,0 +1,190 @@
+"""Tests for scripts/check-deferred-removals.py.
+
+The guard exists because `WalBatchConfig` was promised "at the next major" and
+`v6.0.0` shipped two days later without it. So the test that matters is not that
+the guard passes today — it does, trivially, because the due major has not
+arrived — but that it **refuses** once it has. A gate nobody has seen fail is a
+gate nobody knows is wired.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-deferred-removals.py"
+
+_spec = importlib.util.spec_from_file_location("check_deferred_removals", SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+guard = importlib.util.module_from_spec(_spec)
+sys.modules["check_deferred_removals"] = guard
+_spec.loader.exec_module(guard)
+
+
+def build_tree(root: Path, version: str, contents: "str | None") -> None:
+    """Writes a minimal tree: a workspace manifest and the guarded file."""
+    (root / "Cargo.toml").write_text(
+        f'[workspace.package]\nversion = "{version}"\n', encoding="utf-8"
+    )
+    site = root / "crates/velesdb-core/src"
+    site.mkdir(parents=True, exist_ok=True)
+    if contents is not None:
+        (site / "config.rs").write_text(contents, encoding="utf-8")
+
+
+STILL_THERE = 'pub struct WalBatchConfig {}\nconst S: &str = "wal_batch";\n'
+REMOVED = "// nothing deferred lives here any more\n"
+
+
+class DueDateTests(unittest.TestCase):
+    def test_passes_before_the_promised_major(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_tree(root, "6.0.0", STILL_THERE)
+            self.assertEqual(guard.run(root), 0)
+
+    def test_refuses_once_the_major_arrived_and_the_sites_remain(self) -> None:
+        # The whole point. `v6.0.0` shipped past this promise unnoticed; the
+        # release commit that raises the major must now go red instead.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_tree(root, "7.0.0", STILL_THERE)
+            self.assertEqual(guard.run(root), 1)
+
+    def test_passes_once_the_sites_are_gone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_tree(root, "7.0.0", REMOVED)
+            self.assertEqual(guard.run(root), 0)
+
+    def test_a_deleted_file_counts_as_a_removed_site(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_tree(root, "7.0.0", None)
+            self.assertEqual(guard.run(root), 0)
+
+    def test_a_major_beyond_the_due_one_still_refuses(self) -> None:
+        # A promise missed at 7 is not forgiven by reaching 8.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_tree(root, "8.1.2", STILL_THERE)
+            self.assertEqual(guard.run(root), 1)
+
+
+class UnreadableTreeTests(unittest.TestCase):
+    """A tree the guard cannot read answers 2, never 1."""
+
+    def test_missing_manifest_is_an_error_not_a_refusal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(guard.main(["--root", tmp]), 2)
+
+    def test_unparseable_version_is_an_error_not_a_refusal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Cargo.toml").write_text("[workspace.package]\n", encoding="utf-8")
+            self.assertEqual(guard.main(["--root", tmp]), 2)
+
+
+class VersionReadingTests(unittest.TestCase):
+    """Reading the version wrongly is a silent green, so it gets its own tests."""
+
+    def test_a_dependency_table_above_the_package_section_is_not_the_version(self) -> None:
+        # An unanchored search reads the FIRST line-initial `version =` in the
+        # file. `check-version-sync.py` already carries this scar; re-earning it
+        # here would mean an overdue removal passing as major 1.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Cargo.toml").write_text(
+                '[workspace]\n[workspace.dependencies.some-crate]\nversion = "1.2.3"\n'
+                '[workspace.package]\nversion = "7.0.0"\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(guard.workspace_major(root), 7)
+
+    def test_a_prerelease_version_reads_its_major(self) -> None:
+        # `create-release-tag.sh` accepts a prerelease suffix, so `7.0.0-rc.1` is
+        # a version this repository ships. A pattern demanding a strict triple
+        # would report it as missing and answer 2 on a perfectly readable tree.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "Cargo.toml").write_text(
+                '[workspace.package]\nversion = "7.0.0-rc.1"\n', encoding="utf-8"
+            )
+            self.assertEqual(guard.workspace_major(root), 7)
+
+    def test_a_prerelease_at_the_due_major_still_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            build_tree(root, "7.0.0-rc.1", STILL_THERE)
+            self.assertEqual(guard.run(root), 1)
+
+
+class MalformedEntryTests(unittest.TestCase):
+    """A malformed entry answers 2, not the 1 an uncaught exception would give."""
+
+    def test_a_missing_key_is_an_error(self) -> None:
+        with self.assertRaises(RuntimeError):
+            guard.validate_entry({"what": "x", "remove_at_major": 7, "issue": 1})
+
+    def test_a_non_integer_major_is_an_error(self) -> None:
+        with self.assertRaises(RuntimeError):
+            guard.validate_entry(
+                {"what": "x", "remove_at_major": "7", "issue": 1, "sites": [("a", "b")]}
+            )
+
+    def test_an_entry_with_no_sites_is_an_error(self) -> None:
+        # It would pass the day its major arrives while the code is untouched.
+        with self.assertRaises(RuntimeError):
+            guard.validate_entry(
+                {"what": "x", "remove_at_major": 7, "issue": 1, "sites": []}
+            )
+
+
+class RegistryTests(unittest.TestCase):
+    """The guard registry knows this guard, with a vector for every entry."""
+
+    ROOT = SCRIPT_PATH.parent.parent
+
+    def test_the_guard_is_declared_with_a_refusal_vector(self) -> None:
+        import json
+
+        registry = json.loads(
+            (self.ROOT / "scripts/guards.json").read_text(encoding="utf-8")
+        )
+        declared = [
+            g
+            for g in registry["guards"]
+            if g["script"] == "scripts/check-deferred-removals.py"
+        ]
+        self.assertEqual(len(declared), 1, "the guard must be declared exactly once")
+        # Emptying DEFERRED_REMOVALS is what the vectors make impossible to do
+        # quietly: the v7 tree would stop being refused and this contract breaks.
+        self.assertTrue(declared[0]["must_refuse"], "a strict guard needs vectors")
+
+
+class RealTreeTests(unittest.TestCase):
+    """The entry describes this repository, not an imagined one."""
+
+    ROOT = SCRIPT_PATH.parent.parent
+
+    def test_every_listed_site_exists_today(self) -> None:
+        # A site that never matches is a guard watching nothing: the removal
+        # would "pass" the day the major arrives while the code is untouched.
+        for entry in guard.DEFERRED_REMOVALS:
+            with self.subTest(what=entry["what"]):
+                self.assertEqual(
+                    sorted(guard.surviving_sites(self.ROOT, entry)),
+                    sorted(f"{rel}: {needle}" for rel, needle in entry["sites"]),
+                    "a listed site no longer matches — remove the entry or fix the needle",
+                )
+
+    def test_the_workflow_calls_the_guard(self) -> None:
+        text = (self.ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("scripts/check-deferred-removals.py", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → targets `develop`. ✅

Closes the root cause behind #2174.

## The failure this fixes

`WalBatchConfig` was to be removed "at the next major". The next major shipped
**two days after that was written** — `v6.0.0`, 2026-09-02 — and did not remove
it. `docs/guides/MIGRATION_v6.0.0.md:117-119` even reconfirms that the config
stays.

Nothing was broken and nobody was careless. The constraint lived in a doc
comment and in an issue, and **neither is read by the thing that bumps a
version**. A deferred removal is a promise with a due date; this is the alarm
clock.

## How it works

`scripts/check-deferred-removals.py` holds a short list of removals promised for
a future major, each with every site that must be gone. When the workspace major
reaches the promised version and a site survives, the check fails.

One entry today:

```python
{
    "what": "WalBatchConfig and its [wal_batch] config table",
    "remove_at_major": 7,
    "issue": 2174,
    "sites": [
        ("crates/velesdb-core/src/config.rs", "pub struct WalBatchConfig"),
        ("crates/velesdb-core/src/config.rs", '"wal_batch"'),
    ],
}
```

### Two design decisions

**Fail *on* the bump rather than warn before it.** A warning needs someone
listening at the right moment — which is precisely the failure mode that
produced this file. Failing on the bump needs nobody: the release commit that
raises the major cannot go green until the removal lands.

**List sites individually, not one symbol.** A removal that leaves one behind is
not done — and #2174's own text missed the `ENV_SECTIONS` entry, which is
exactly that mistake made once already.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The tests do not stop at "it passes today", which it does trivially since the
due major has not arrived. They pin the **refusal**:

| test | what it proves |
|---|---|
| `passes_before_the_promised_major` | major 6, entry due at 7 → 0 |
| **`refuses_once_the_major_arrived_and_the_sites_remain`** | **major 7, sites present → 1 — the case v6.0.0 walked past** |
| `passes_once_the_sites_are_gone` | major 7, sites removed → 0 |
| `a_deleted_file_counts_as_a_removed_site` | the file itself gone → 0 |
| `a_major_beyond_the_due_one_still_refuses` | major 8 → 1; a promise missed at 7 is not forgiven by reaching 8 |
| `missing_manifest_is_an_error_not_a_refusal` | → **2**, so a refusal it never made cannot look like one |
| `unparseable_version_is_an_error_not_a_refusal` | → 2 |
| `every_listed_site_exists_today` | a needle that never matches is a guard watching nothing — it would "pass" the day the major arrives while the code is untouched |
| `the_workflow_calls_the_guard` | wiring |

The wiring test failed first, before the `ci.yml` entry existed. That is what it
is for.

`python3 -m unittest scripts.tests.test_check_deferred_removals` → **OK**.
`ci.yml` parses as YAML. The guard on this tree prints
`PASSED: workspace major is 6; 1 deferred removal(s) not yet due, none overdue.`

Wired beside the version-sync guard, which is where the bump is already policed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Review history

An adversarial review returned **BLOCKING**, and the headline finding was that
this PR would have turned CI red: the repository keeps a guard registry
(`scripts/guards.json`) and `test_ci_gate_reachability.py` requires every
guard-shaped script — and every script a workflow invokes — to be declared
there. This one was not. The irony is exact: a change whose thesis is *"a
promise nothing reads is not a guarantee"* was adding a guard the guard registry
did not know about.

Registering it also closed a second finding for free. The review noted the list
could be **emptied silently**, and that the failure message named that bypass
without controlling it. Refusal vectors close it by construction: delete the
entry and the v7 tree stops being refused, so `test_guard_refusal_vectors.py`
breaks in the same commit.

The rest, all fixed rather than argued with:

- **The version search was not anchored on `[workspace.package]`** — it took the
  first line-initial `version =` in the file, which a long-form
  `[workspace.dependencies.x]` table above the package section would win, making
  an overdue removal pass as major 1. `check-version-sync.py` already carries
  that scar with a comment recording the incident. A second refusal vector now
  pins exactly that tree.
- **A prerelease exited 2 instead of 1.** `create-release-tag.sh` ships
  prereleases, so `7.0.0-rc.1` must read as major 7, not as a missing version.
- **A malformed entry escaped as `TypeError`**, and Python exits 1 on an
  uncaught exception — a refusal this guard never made wearing the exit code of
  one it did. Entries are validated and answer 2. An entry with no sites is
  refused outright: it would pass the day its major arrives while the code is
  untouched.
- **Sites under-listed.** They now reach `docs/guides/CONFIGURATION.md` and
  `docs/CORE_WIRING_DEBT.md`, which the compiler cannot police.
  `docs/guides/MIGRATION_v6.0.0.md` is deliberately excluded — it records that
  the table stayed in 6.0.0, which remains true after 7.0.0 removes it. A
  historical note is not stale because history moved on.

The review also **confirmed the claim this PR makes about its own timing**: the
chain bump → `CI Success` → `lint` → guard is real, checked against the actual
`chore(release): prepare 6.0.0` commit, which touches `Cargo.toml`, `crates/**`
and `.github/workflows/**` and so clears the `paths:` filter.

Now: `test_check_deferred_removals` 16 tests OK, `test_guard_refusal_vectors` 8
OK, `test_ci_gate_reachability` 97 OK.
