### PR TITLE
chore(config): deprecate storage.{data_dir,mmap_cache_mb,vector_alignment}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   three have no engine counterpart to wire them to at all (`data_dir` also
   conflicts irreducibly with the path passed to `Database::open`), unlike
   `storage_mode` and the rest of `[hnsw]`/`[search]`, which are still
-  pending a wiring decision. They now get the same accept-and-warn
-  deprecation cycle `[wal_batch]` (#2078) is already running:
-  `VelesConfig::validate` logs a warning naming exactly which of the three
-  is set away from its default, and removal targets the next major. No
-  behavior changes — a config file setting them today keeps loading exactly
-  as before.
+  pending a wiring decision. They now get the same warn-not-reject
+  deprecation cycle `[wal_batch]` (#2078) is already running — though
+  `[wal_batch]` has no validation at all, while `mmap_cache_mb` keeps its
+  pre-existing hard range check (left as is; loosening it is a separate
+  change). `VelesConfig::validate` logs a warning naming exactly which of
+  the three is set away from its default, and removal targets the next
+  major (tracked by `scripts/check-deferred-removals.py`). No behavior
+  changes — a config file setting them today keeps loading exactly as
+  before.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- **`[storage]` `data_dir`, `mmap_cache_mb` and `vector_alignment` — parsed
+  and validated, never applied.** Issue #2087's per-knob audit found these
+  three have no engine counterpart to wire them to at all (`data_dir` also
+  conflicts irreducibly with the path passed to `Database::open`), unlike
+  `storage_mode` and the rest of `[hnsw]`/`[search]`, which are still
+  pending a wiring decision. They now get the same accept-and-warn
+  deprecation cycle `[wal_batch]` (#2078) is already running:
+  `VelesConfig::validate` logs a warning naming exactly which of the three
+  is set away from its default, and removal targets the next major. No
+  behavior changes — a config file setting them today keeps loading exactly
+  as before.
+
 ### Fixed
 
 - **30 broken rustdoc intra-doc links in `velesdb-core`, and the two lints that

--- a/crates/tauri-plugin-velesdb/examples/production-config/velesdb.toml
+++ b/crates/tauri-plugin-velesdb/examples/production-config/velesdb.toml
@@ -48,13 +48,14 @@ max_layers = 0
 
 [storage]
 # "mmap" or "memory". mmap keeps the resident set small — the right default for
-# a desktop app that may sit in the background for hours.
+# a desktop app that may sit in the background for hours. Reserved — parsed
+# but not yet applied by the engine (core issue #2087).
 storage_mode = "mmap"
 
-# Mmap cache in megabytes. Range: 1..=1048576.
+# mmap_cache_mb and vector_alignment are deprecated (core issue #2087): no
+# engine counterpart exists to wire them to. Parsed only for backward
+# compatibility with existing config files; tuning them has no effect.
 mmap_cache_mb = 1024
-
-# Vector alignment in bytes; 64 matches the cache line on x86_64 and ARM64.
 vector_alignment = 64
 
 [limits]

--- a/crates/velesdb-core/src/collection/search/query/scan_cap_observability_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/scan_cap_observability_tests.rs
@@ -11,70 +11,7 @@
 #![cfg(all(test, feature = "persistence"))]
 
 use crate::point::Point;
-use crate::test_fixtures::fixtures::{make_point_with_payload, setup_collection};
-use std::sync::{Arc, Mutex};
-
-// ============================================================================
-// Minimal warn-capturing tracing subscriber (no extra dev-dependency).
-// ============================================================================
-
-/// Captures WARN-and-worse events as flat `field=value` strings.
-#[derive(Default)]
-struct WarnSink {
-    events: Mutex<Vec<String>>,
-}
-
-struct FlattenVisitor<'a>(&'a mut String);
-
-impl tracing::field::Visit for FlattenVisitor<'_> {
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        use std::fmt::Write;
-        let _ = write!(self.0, "{}={:?} ", field.name(), value);
-    }
-}
-
-struct WarnCapture {
-    sink: Arc<WarnSink>,
-}
-
-impl tracing::Subscriber for WarnCapture {
-    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
-        // In `tracing`, more severe levels compare LESS (ERROR < WARN < INFO).
-        *metadata.level() <= tracing::Level::WARN
-    }
-
-    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
-        tracing::span::Id::from_u64(1)
-    }
-
-    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
-
-    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
-
-    fn event(&self, event: &tracing::Event<'_>) {
-        let mut line = String::new();
-        event.record(&mut FlattenVisitor(&mut line));
-        self.sink
-            .events
-            .lock()
-            .expect("test: warn sink lock")
-            .push(line);
-    }
-
-    fn enter(&self, _: &tracing::span::Id) {}
-
-    fn exit(&self, _: &tracing::span::Id) {}
-}
-
-/// Runs `f` with a warn-capturing subscriber installed (thread-local) and
-/// returns the captured WARN+ events.
-fn capture_warns<T>(f: impl FnOnce() -> T) -> (T, Vec<String>) {
-    let sink = Arc::new(WarnSink::default());
-    let subscriber = WarnCapture { sink: sink.clone() };
-    let out = tracing::subscriber::with_default(subscriber, f);
-    let events = sink.events.lock().expect("test: warn sink lock").clone();
-    (out, events)
-}
+use crate::test_fixtures::fixtures::{capture_warns, make_point_with_payload, setup_collection};
 
 // ============================================================================
 // Fixture

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -172,12 +172,20 @@ pub mod server {
 
     /// Storage configuration section.
     ///
-    /// **Reserved — parsed and validated, not yet applied.** `[limits]`
-    /// and `[hnsw]` reach the engine; this section does not.
-    /// `VelesConfig::validate` warns when it deviates from its defaults.
-    /// Wiring is tracked in issue #2087 (`data_dir` in particular conflicts
-    /// with the path passed to `Database::open` and may go through
-    /// deprecation instead).
+    /// Issue #2087's per-knob verdict split this section in two:
+    ///
+    /// - **`data_dir`, `mmap_cache_mb`, `vector_alignment` are deprecated.**
+    ///   No engine counterpart exists to wire them to — not merely unwired,
+    ///   *absent* — and `data_dir` also conflicts irreducibly with the path
+    ///   passed to `Database::open`. Parsed and validated only so existing
+    ///   TOML files keep loading; removal targets the next major, the same
+    ///   accept-and-warn cycle `[wal_batch]` (#2078) is already running.
+    ///   [`crate::config::VelesConfig::validate`] warns when any of the
+    ///   three is set away from its default.
+    /// - **`storage_mode` is still reserved**, pending its own decision
+    ///   (distinct from `quantization::StorageMode`; whether the engine has
+    ///   a memory-only mode to select is not established). Also reported by
+    ///   the same validation when set away from its default.
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(default)]
     pub struct StorageConfig {

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -179,7 +179,11 @@ pub mod server {
     ///   *absent* — and `data_dir` also conflicts irreducibly with the path
     ///   passed to `Database::open`. Parsed and validated only so existing
     ///   TOML files keep loading; removal targets the next major, the same
-    ///   accept-and-warn cycle `[wal_batch]` (#2078) is already running.
+    ///   warn-not-reject cycle `[wal_batch]` (#2078) is already running —
+    ///   though unlike `[wal_batch]`, which has no validation at all,
+    ///   `mmap_cache_mb` keeps its pre-existing hard range check (`0` and
+    ///   values over the cap still fail load), left as is on purpose rather
+    ///   than loosened as a second change bundled into this one.
     ///   [`crate::config::VelesConfig::validate`] warns when any of the
     ///   three is set away from its default.
     /// - **`storage_mode` is still reserved**, pending its own decision

--- a/crates/velesdb-core/src/config_tests.rs
+++ b/crates/velesdb-core/src/config_tests.rs
@@ -648,4 +648,36 @@ max_batch_size = 64
         assert!(parsed.wal_batch.enabled);
         assert_eq!(parsed.wal_batch.max_batch_size, 64);
     }
+
+    // ========================================================================
+    // Deprecated [storage] fields (issue #2087) — same accept-and-warn
+    // treatment as [wal_batch] above: a TOML file setting them must still
+    // load, and the deprecation must be reported end to end from the parsed
+    // config, not only from a struct built by field assignment.
+    // ========================================================================
+
+    #[test]
+    fn test_veles_config_toml_with_deprecated_storage_fields_still_loads() {
+        let toml = r#"
+[storage]
+data_dir = "/var/lib/velesdb"
+mmap_cache_mb = 2048
+vector_alignment = 32
+"#;
+        let config = VelesConfig::from_toml(toml).expect("parse");
+
+        assert_eq!(config.storage.data_dir, "/var/lib/velesdb");
+        assert_eq!(config.storage.mmap_cache_mb, 2048);
+        assert_eq!(config.storage.vector_alignment, 32);
+        assert_eq!(
+            config.deprecated_storage_entries(),
+            vec![
+                "storage.data_dir",
+                "storage.mmap_cache_mb",
+                "storage.vector_alignment",
+            ]
+        );
+        // storage_mode was left at its default, so it stays out of both reports.
+        assert!(config.inert_engine_entries().is_empty());
+    }
 }

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -180,9 +180,14 @@ impl VelesConfig {
     /// `storage.vector_alignment` have no engine counterpart to wire them
     /// to (issue #2087's per-knob verdict) — not merely unwired, *absent*.
     /// Warn — rather than reject — when a config sets any of them away from
-    /// its default, the same accept-and-warn treatment [`Self::warn_inert_wal_batch`]
-    /// gives `[wal_batch]`, so existing files keep loading while no
-    /// deployment silently believes these knobs do anything.
+    /// its default, so existing files keep loading while no deployment
+    /// silently believes these knobs do anything. This is only *half* the
+    /// same treatment [`Self::warn_inert_wal_batch`] gives `[wal_batch]`:
+    /// that field has no validation at all, while `validate_storage` keeps a
+    /// hard range check on `mmap_cache_mb` (`0` and values over the cap are
+    /// still rejected). That check predates this deprecation and is left as
+    /// is deliberately — loosening it is a second, separate behavior change
+    /// this PR does not make.
     /// `storage.storage_mode` is a separate, still-open decision and stays
     /// reported by [`Self::warn_inert_engine_sections`] instead.
     fn warn_deprecated_storage_fields(&self) {

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -85,22 +85,29 @@ impl VelesConfig {
         self.validate_storage()?;
         self.validate_logging()?;
         self.warn_inert_wal_batch();
+        self.warn_deprecated_storage_fields();
         self.warn_inert_engine_sections();
         Ok(())
     }
 
-    /// The `[search]`, `[storage]` and `[quantization]` sections are parsed
-    /// and validated but not yet applied (issue #2087). Warn — rather than
-    /// reject — when a config sets any of them away from its defaults, so
+    /// The `[search]` section and `storage.storage_mode` are parsed and
+    /// validated but not yet applied (issue #2087). Warn — rather than
+    /// reject — when a config sets either away from its defaults, so
     /// existing files keep loading while no deployment silently believes
     /// those knobs work.
     ///
     /// `[hnsw]` is no longer listed wholesale: `m` and `ef_construction` are
     /// applied at collection creation. Only `max_layers` remains inert — the
     /// layer count is drawn per node by the level generator and no engine
-    /// path caps it — so the warning narrows to that single field. Reporting
-    /// the field rather than the section is the point: a warning that fires
-    /// on knobs that now work would train readers to ignore it.
+    /// path caps it — so the warning narrows to that single field. `[storage]`
+    /// is narrowed the same way: `data_dir`, `mmap_cache_mb` and
+    /// `vector_alignment` are deprecated rather than inert (no engine
+    /// counterpart to wire them to at all) and get their own warning in
+    /// [`Self::warn_deprecated_storage_fields`]; only `storage_mode` — still
+    /// awaiting its own decision — stays reported here. Reporting the field
+    /// rather than the section is the point: a warning that fires on knobs
+    /// that now work, or that are leaving rather than pending, would train
+    /// readers to ignore it.
     ///
     /// Serde-value comparison instead of `PartialEq` derives: the sections
     /// carry enums and nested types, and this runs once per config load.
@@ -143,11 +150,9 @@ impl VelesConfig {
         if self.hnsw.max_layers != crate::config::HnswConfig::default().max_layers {
             inert.push("hnsw.max_layers");
         }
-        if deviates(
-            &self.storage,
-            &crate::config::server::StorageConfig::default(),
-        ) {
-            inert.push("[storage]");
+        if self.storage.storage_mode != crate::config::server::StorageConfig::default().storage_mode
+        {
+            inert.push("storage.storage_mode");
         }
         if deviates(
             &self.quantization,
@@ -169,6 +174,46 @@ impl VelesConfig {
                  (see issue #2078)"
             );
         }
+    }
+
+    /// `storage.data_dir`, `storage.mmap_cache_mb` and
+    /// `storage.vector_alignment` have no engine counterpart to wire them
+    /// to (issue #2087's per-knob verdict) — not merely unwired, *absent*.
+    /// Warn — rather than reject — when a config sets any of them away from
+    /// its default, the same accept-and-warn treatment [`Self::warn_inert_wal_batch`]
+    /// gives `[wal_batch]`, so existing files keep loading while no
+    /// deployment silently believes these knobs do anything.
+    /// `storage.storage_mode` is a separate, still-open decision and stays
+    /// reported by [`Self::warn_inert_engine_sections`] instead.
+    fn warn_deprecated_storage_fields(&self) {
+        let deprecated = self.deprecated_storage_entries();
+        if !deprecated.is_empty() {
+            tracing::warn!(
+                deprecated = deprecated.join(", "),
+                "these [storage] entries are parsed but have no engine \
+                 counterpart and will be removed at the next major; see \
+                 issue #2087"
+            );
+        }
+    }
+
+    /// The `[storage]` fields with no engine counterpart, as they would be
+    /// named in a TOML file. Split out of
+    /// [`Self::warn_deprecated_storage_fields`] so the set is assertable —
+    /// mirrors [`Self::inert_engine_entries`].
+    pub(crate) fn deprecated_storage_entries(&self) -> Vec<&'static str> {
+        let default = crate::config::server::StorageConfig::default();
+        let mut deprecated = Vec::new();
+        if self.storage.data_dir != default.data_dir {
+            deprecated.push("storage.data_dir");
+        }
+        if self.storage.mmap_cache_mb != default.mmap_cache_mb {
+            deprecated.push("storage.mmap_cache_mb");
+        }
+        if self.storage.vector_alignment != default.vector_alignment {
+            deprecated.push("storage.vector_alignment");
+        }
+        deprecated
     }
 
     fn validate_search(&self) -> Result<(), ConfigError> {

--- a/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
+++ b/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
@@ -326,10 +326,31 @@ fn test_max_layers_reported_alongside_a_configured_wired_knob() {
 fn test_still_unwired_sections_are_reported_wholesale() {
     let mut config = VelesConfig::default();
     config.search.max_results = 42;
-    config.storage.mmap_cache_mb = 2048;
+    config.storage.storage_mode = "memory".to_string();
     assert_eq!(
         config.inert_engine_entries(),
-        vec!["[search]", "[storage]"],
-        "sections with no wired knob stay reported as whole sections"
+        vec!["[search]", "storage.storage_mode"],
+        "[search] has no wired knob and stays reported as a whole section; \
+         storage_mode is the one [storage] field still awaiting a decision"
+    );
+}
+
+#[test]
+fn test_deprecated_storage_fields_are_not_reported_inert() {
+    // data_dir/mmap_cache_mb/vector_alignment have no engine counterpart at
+    // all (issue #2087's verdict) and get their own deprecation warning
+    // instead of being reported here as pending wiring.
+    let mut config = VelesConfig::default();
+    config.storage.data_dir = "/var/lib/velesdb".to_string();
+    config.storage.mmap_cache_mb = 2048;
+    config.storage.vector_alignment = 32;
+    assert!(config.inert_engine_entries().is_empty());
+    assert_eq!(
+        config.deprecated_storage_entries(),
+        vec![
+            "storage.data_dir",
+            "storage.mmap_cache_mb",
+            "storage.vector_alignment",
+        ]
     );
 }

--- a/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
+++ b/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
@@ -10,6 +10,7 @@
 use crate::config::VelesConfig;
 use crate::index::hnsw::HnswParams;
 use crate::quantization::StorageMode;
+use crate::test_fixtures::fixtures::capture_warns;
 use crate::{Database, DistanceMetric};
 use tempfile::tempdir;
 
@@ -323,7 +324,7 @@ fn test_max_layers_reported_alongside_a_configured_wired_knob() {
 }
 
 #[test]
-fn test_still_unwired_sections_are_reported_wholesale() {
+fn test_search_reported_wholesale_storage_mode_reported_by_field() {
     let mut config = VelesConfig::default();
     config.search.max_results = 42;
     config.storage.storage_mode = "memory".to_string();
@@ -332,6 +333,42 @@ fn test_still_unwired_sections_are_reported_wholesale() {
         vec!["[search]", "storage.storage_mode"],
         "[search] has no wired knob and stays reported as a whole section; \
          storage_mode is the one [storage] field still awaiting a decision"
+    );
+}
+
+#[test]
+fn test_deprecated_storage_fields_emit_a_warning() {
+    // The list built by deprecated_storage_entries() is assertable; the
+    // tracing::warn! call in warn_deprecated_storage_fields() that actually
+    // fires it is not, short of capturing it — deleting that call would
+    // leave every other test in this file green while the warning it is
+    // meant to guarantee silently stopped firing.
+    let mut config = VelesConfig::default();
+    config.storage.mmap_cache_mb = 2048;
+
+    let ((), warns) = capture_warns(|| {
+        config
+            .validate()
+            .expect("test: default config plus one deprecated field validates");
+    });
+
+    assert!(
+        warns.iter().any(|w| w.contains("storage.mmap_cache_mb")),
+        "expected a warning naming the deviating field, got: {warns:?}"
+    );
+}
+
+#[test]
+fn test_default_config_emits_no_deprecation_warning() {
+    let config = VelesConfig::default();
+
+    let ((), warns) = capture_warns(|| {
+        config.validate().expect("test: default config validates");
+    });
+
+    assert!(
+        warns.is_empty(),
+        "a default config must not warn about anything: {warns:?}"
     );
 }
 

--- a/crates/velesdb-core/src/fixtures_tests.rs
+++ b/crates/velesdb-core/src/fixtures_tests.rs
@@ -2,6 +2,7 @@ use crate::collection::Collection;
 use crate::distance::DistanceMetric;
 use crate::point::Point;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 
 /// Creates a test collection with the given dimension and cosine metric.
@@ -45,4 +46,69 @@ pub fn make_point_with_payload(id: u64, vector: Vec<f32>, payload: serde_json::V
         payload: Some(payload),
         sparse_vectors: None,
     }
+}
+
+// ============================================================================
+// Minimal warn-capturing tracing subscriber (no extra dev-dependency).
+// ============================================================================
+
+/// Captures WARN-and-worse events as flat `field=value` strings.
+#[derive(Default)]
+struct WarnSink {
+    events: Mutex<Vec<String>>,
+}
+
+struct FlattenVisitor<'a>(&'a mut String);
+
+impl tracing::field::Visit for FlattenVisitor<'_> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write;
+        let _ = write!(self.0, "{}={:?} ", field.name(), value);
+    }
+}
+
+struct WarnCapture {
+    sink: Arc<WarnSink>,
+}
+
+impl tracing::Subscriber for WarnCapture {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        // In `tracing`, more severe levels compare LESS (ERROR < WARN < INFO).
+        *metadata.level() <= tracing::Level::WARN
+    }
+
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut line = String::new();
+        event.record(&mut FlattenVisitor(&mut line));
+        self.sink
+            .events
+            .lock()
+            .expect("test: warn sink lock")
+            .push(line);
+    }
+
+    fn enter(&self, _: &tracing::span::Id) {}
+
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// Runs `f` with a warn-capturing subscriber installed (thread-local) and
+/// returns the captured WARN+ events. Shared by any test that needs to prove
+/// a `tracing::warn!` actually fires — a `tracing` warning is not otherwise
+/// observable from a test.
+#[allow(dead_code)] // Available for future test adoption.
+pub fn capture_warns<T>(f: impl FnOnce() -> T) -> (T, Vec<String>) {
+    let sink = Arc::new(WarnSink::default());
+    let subscriber = WarnCapture { sink: sink.clone() };
+    let out = tracing::subscriber::with_default(subscriber, f);
+    let events = sink.events.lock().expect("test: warn sink lock").clone();
+    (out, events)
 }

--- a/crates/velesdb-mobile/examples/velesdb.toml
+++ b/crates/velesdb-mobile/examples/velesdb.toml
@@ -53,14 +53,14 @@ max_layers = 0
 
 [storage]
 # "mmap" or "memory". mmap keeps the resident set small, which is what you
-# want on a phone; "memory" trades RAM for latency.
+# want on a phone; "memory" trades RAM for latency. Reserved — parsed but
+# not yet applied by the engine (core issue #2087).
 storage_mode = "mmap"
 
-# Mmap cache in megabytes. 1024 is the desktop default and is far too generous
-# for a phone — 128 or 256 is a more realistic starting point.
+# mmap_cache_mb and vector_alignment are deprecated (core issue #2087): no
+# engine counterpart exists to wire them to. Parsed only for backward
+# compatibility with existing config files; tuning them has no effect.
 mmap_cache_mb = 256
-
-# Vector alignment in bytes; 64 matches the cache line on ARM64 and x86_64.
 vector_alignment = 64
 
 [limits]

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -677,6 +677,11 @@ impl HnswConfigOptions {
 /// All fields are optional — unspecified fields fall back to the engine
 /// defaults (`data_dir="./velesdb_data"`, `storage_mode="mmap"`,
 /// `mmap_cache_mb=1024`, `vector_alignment=64`).
+///
+/// None of these reach the engine yet (core issue #2087): `storage_mode` is
+/// still pending its own wiring decision, and `data_dir`/`mmap_cache_mb`/
+/// `vector_alignment` are deprecated outright — no engine counterpart
+/// exists to wire them to — and targeted for removal at the next major.
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct StorageOptions {

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -677,11 +677,6 @@ impl HnswConfigOptions {
 /// All fields are optional — unspecified fields fall back to the engine
 /// defaults (`data_dir="./velesdb_data"`, `storage_mode="mmap"`,
 /// `mmap_cache_mb=1024`, `vector_alignment=64`).
-///
-/// None of these reach the engine yet (core issue #2087): `storage_mode` is
-/// still pending its own wiring decision, and `data_dir`/`mmap_cache_mb`/
-/// `vector_alignment` are deprecated outright — no engine counterpart
-/// exists to wire them to — and targeted for removal at the next major.
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct StorageOptions {

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -673,23 +673,23 @@ impl HnswConfigOptions {
 
 /// Storage engine settings mapped to
 /// [`velesdb_core::config::StorageConfig`] (the `[storage]` TOML section).
-///
+/// None of these reach the engine yet (core issue #2087) — see each field.
 /// All fields are optional — unspecified fields fall back to the engine
 /// defaults (`data_dir="./velesdb_data"`, `storage_mode="mmap"`,
 /// `mmap_cache_mb=1024`, `vector_alignment=64`).
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct StorageOptions {
-    /// Data directory path. Default: `"./velesdb_data"`.
+    /// Data directory path. Default: `"./velesdb_data"`. Deprecated (core #2087): no engine counterpart, targeted for removal at 7.0.0.
     #[pyo3(get, set)]
     pub data_dir: Option<String>,
-    /// Storage mode: `"mmap"` or `"memory"`. Default: `"mmap"`.
+    /// Storage mode: `"mmap"` or `"memory"`. Default: `"mmap"`. Reserved (core #2087): parsed but not yet applied.
     #[pyo3(get, set)]
     pub storage_mode: Option<String>,
-    /// Mmap cache size in megabytes. Default: 1024.
+    /// Mmap cache size in megabytes. Default: 1024. Deprecated (core #2087): no engine counterpart, targeted for removal at 7.0.0.
     #[pyo3(get, set)]
     pub mmap_cache_mb: Option<usize>,
-    /// Vector alignment in bytes. Default: 64.
+    /// Vector alignment in bytes. Default: 64. Deprecated (core #2087): no engine counterpart, targeted for removal at 7.0.0.
     #[pyo3(get, set)]
     pub vector_alignment: Option<usize>,
 }

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -187,6 +187,7 @@ max_layers = 0
 [storage]
 # Répertoire de données principal
 # Default: "./velesdb_data"
+# Deprecated (#2087) — parsed but has no effect; targeted for removal at 7.0.0.
 data_dir = "./velesdb_data"
 
 # Mode de stockage des vecteurs
@@ -194,16 +195,17 @@ data_dir = "./velesdb_data"
 # - mmap: Fichiers mappés en mémoire (recommandé pour grands datasets)
 # - memory: Tout en RAM (plus rapide, limité par RAM disponible)
 # Default: "mmap"
+# Reserved (#2087) — parsed but not yet applied by the engine.
 storage_mode = "mmap"
 
 # Taille maximale du cache mmap en mégaoctets
-# Range: 64 - 65536 (64 GB max)
 # Default: 1024 (1 GB)
+# Deprecated (#2087) — parsed but has no effect; targeted for removal at 7.0.0.
 mmap_cache_mb = 1024
 
 # Alignement mémoire pour les vecteurs (octets)
-# Valeurs: 32 | 64 | 128
-# Default: 64 (optimal pour la plupart des CPUs)
+# Default: 64
+# Deprecated (#2087) — parsed but has no effect; targeted for removal at 7.0.0.
 vector_alignment = 64
 
 # -----------------------------------------------------------------------------
@@ -406,10 +408,12 @@ name kept as they are:
 | `VELESDB_WAL_BATCH_ENABLED` | `wal_batch.enabled` | `false` |
 | `VELESDB_LOGGING_LEVEL` | `logging.level` | `debug` |
 
-Setting one of these is exactly equivalent to setting its TOML key — so a
-**reserved** key stays reserved when set this way. `VELESDB_SEARCH_MAX_RESULTS`
+Setting one of these is exactly equivalent to setting its TOML key. Most are
+**reserved** and stay reserved when set this way: `VELESDB_SEARCH_MAX_RESULTS`
 is parsed, validated and applied by nothing, just like `[search] max_results`;
 see the note at the top of this guide for what the engine acts on.
+`VELESDB_STORAGE_DATA_DIR` is stronger than reserved — `storage.data_dir` is
+**deprecated**, not merely unwired; see [Section \[storage\]](#section-storage).
 
 Note `VELESDB_STORAGE_STORAGE_MODE`, not `VELESDB_STORAGE_MODE`: the section is
 `storage` and the field is `storage_mode`. Earlier revisions of this table
@@ -578,10 +582,13 @@ reserved: no engine counterpart exists to wire them to at all, and
 `data_dir` also conflicts irreducibly with the path passed to
 `Database::open`. They are parsed and validated only so existing TOML files
 keep loading, and are targeted for removal at the next major — the same
-accept-and-warn cycle `[wal_batch]` (#2078) is already running.
-`VelesConfig::validate` warns when any of the three is set away from its
-default. `storage_mode` is a separate, still-open decision (distinct from
-`quantization::StorageMode`) and stays reserved rather than deprecated.
+warn-not-reject cycle `[wal_batch]` (#2078) is already running, though
+`[wal_batch]` has no validation at all while `mmap_cache_mb` keeps its
+pre-existing hard range check (`0` and values over the cap still fail load
+— left as is; loosening it would be a second change). `VelesConfig::validate`
+warns when any of the three is set away from its default. `storage_mode` is
+a separate, still-open decision (distinct from `quantization::StorageMode`)
+and stays reserved rather than deprecated.
 
 ### Section [limits]
 
@@ -681,8 +688,7 @@ unaffected.
 default_mode = "fast"  # Latence minimale pour dev
 
 [storage]
-data_dir = "./dev_data"
-storage_mode = "memory"  # Tout en RAM
+storage_mode = "memory"  # Tout en RAM — reserved (#2087), not yet applied
 
 [logging]
 level = "debug"
@@ -700,10 +706,7 @@ m = 48
 ef_construction = 600
 
 [storage]
-data_dir = "/var/lib/velesdb"
-storage_mode = "mmap"
-mmap_cache_mb = 4096
-vector_alignment = 64
+storage_mode = "mmap"  # reserved (#2087), not yet applied
 
 [server]
 host = "0.0.0.0"

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 6.0.0 — Last updated: 2026-08-08*
+*Version 6.0.0 — Last updated: 2026-09-07*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -49,13 +49,18 @@ To point at a file anywhere else, pass it explicitly:
 > collection and ingest boundaries, and `[hnsw]`'s `m` / `ef_construction`
 > are applied when a collection's index is created (see the precedence chain
 > under [Section \[hnsw\]](#section-hnsw)). Everything else below is parsed
-> and validated but **not** wired: `[search]`, `[storage]`, `[quantization]`
-> and `hnsw.max_layers` (issue #2087), and `[wal_batch]` is parsed and
-> ignored (issue #2078) — its group-commit front was deleted as unwired, and
-> the batch write APIs already pay one durability barrier per call. Setting
-> any unwired key away from its default logs a warning at load, naming
-> exactly what is inert. Query-time overrides (`WITH (ef_search = N)`) are a
-> separate, working mechanism, as are per-collection creation options.
+> and validated but **not** wired: `[search]`, `[quantization]`,
+> `hnsw.max_layers` and `storage.storage_mode` — each still pending its own
+> wiring decision (issue #2087). Setting any of these away from its default
+> logs a warning at load, naming exactly what is inert. Three more
+> `[storage]` fields — `data_dir`, `mmap_cache_mb`, `vector_alignment` — are
+> not pending anything: no engine counterpart exists to wire them to, so
+> they are **deprecated** instead (their own warning, same treatment as
+> `[wal_batch]` below) and targeted for removal at the next major.
+> `[wal_batch]` is parsed and ignored (issue #2078) — its group-commit front
+> was deleted as unwired, and the batch write APIs already pay one
+> durability barrier per call. Query-time overrides (`WITH (ef_search = N)`)
+> are a separate, working mechanism, as are per-collection creation options.
 
 Both binaries can load the **same** file, but only the *engine* sections —
 `[search]`, `[hnsw]`, `[storage]`, `[limits]`, `[quantization]`,
@@ -561,12 +566,22 @@ section — it sizes the candidate pool of one query; nothing here does.
 
 ### Section [storage]
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `data_dir` | string | `"./velesdb_data"` | Data directory |
-| `storage_mode` | string | `"mmap"` | Mode: mmap or memory |
-| `mmap_cache_mb` | int | `1024` | mmap cache in MB |
-| `vector_alignment` | int | `64` | Memory alignment |
+| Key | Type | Default | Description | Applied |
+|-----|------|---------|-------------|---------|
+| `data_dir` | string | `"./velesdb_data"` | Data directory | **no** — deprecated (#2087) |
+| `storage_mode` | string | `"mmap"` | Mode: mmap or memory | **no** — reserved (#2087) |
+| `mmap_cache_mb` | int | `1024` | mmap cache in MB | **no** — deprecated (#2087) |
+| `vector_alignment` | int | `64` | Memory alignment | **no** — deprecated (#2087) |
+
+`data_dir`, `mmap_cache_mb` and `vector_alignment` are deprecated, not
+reserved: no engine counterpart exists to wire them to at all, and
+`data_dir` also conflicts irreducibly with the path passed to
+`Database::open`. They are parsed and validated only so existing TOML files
+keep loading, and are targeted for removal at the next major — the same
+accept-and-warn cycle `[wal_batch]` (#2078) is already running.
+`VelesConfig::validate` warns when any of the three is set away from its
+default. `storage_mode` is a separate, still-open decision (distinct from
+`quantization::StorageMode`) and stays reserved rather than deprecated.
 
 ### Section [limits]
 

--- a/scripts/check-deferred-removals.py
+++ b/scripts/check-deferred-removals.py
@@ -57,6 +57,23 @@ DEFERRED_REMOVALS: "list[dict]" = [
         # removes it — a historical note is not stale merely because history
         # moved on, and forcing its deletion would falsify the record.
     },
+    {
+        "what": "the three inert [storage] entries (#2087)",
+        "remove_at_major": 7,
+        "issue": 2087,
+        # The Rust fields, the guide that documents them, and the Python option
+        # mirror that still writes them through `to_core()`. The mirror is listed
+        # because the compiler will not fail when the core fields go: the Python
+        # surface is a separate struct that would keep advertising settings with
+        # nowhere left to land.
+        "sites": [
+            ("crates/velesdb-core/src/config.rs", "pub data_dir: String"),
+            ("crates/velesdb-core/src/config.rs", "pub mmap_cache_mb: usize"),
+            ("crates/velesdb-core/src/config.rs", "pub vector_alignment: usize"),
+            ("crates/velesdb-python/src/options.rs", "pub mmap_cache_mb:"),
+            ("docs/guides/CONFIGURATION.md", "mmap_cache_mb"),
+        ],
+    },
 ]
 
 #: Anchored inside `[workspace.package]`, and matching any version string

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1316,6 +1316,20 @@
             "--root",
             "{root}"
           ]
+        },
+        {
+          "vector": "the [storage] entries promised for 7.0.0 (#2087) survived the major",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"7.0.0\"\n",
+            "crates/velesdb-core/src/config.rs": "pub struct S { pub mmap_cache_mb: usize }\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"7.0.0\"\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
         }
       ]
     }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`chore/*` → targets `develop`. ✅

## Description

Issue #2087's per-knob audit split `[storage]` in two: `data_dir`, `mmap_cache_mb` and `vector_alignment` have no engine counterpart to wire them to at all (`data_dir` also conflicts irreducibly with the path passed to `Database::open`), unlike `storage_mode`, which is still pending its own wiring decision.

This gives the three the same accept-and-warn deprecation cycle `[wal_batch]` (#2078) is already running: `VelesConfig::validate` now warns, naming exactly which of the three deviates from its default, instead of folding them into the generic "still inert" report. `storage_mode` keeps being reported by `inert_engine_entries` as a single field — the same narrowing `hnsw.max_layers` already got.

**No behavior change.** A config file setting any of these three today keeps loading and validating exactly as before; only the warning text and the `inert_engine_entries()`/new `deprecated_storage_entries()` reporting change.

Related: #2087 (leaves this as one of its follow-ups), precedent: #2078/#2082 (`[wal_batch]`'s own accept-and-warn cycle).

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests — `cargo test -p velesdb-core --features persistence storage -- --test-threads=1` (284 lib tests + integration suites, 0 failed), including two new/updated tests asserting `inert_engine_entries()` / `deprecated_storage_entries()` split correctly.
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

Also ran: `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` (clean), `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` (clean), `PYO3_PYTHON=python3 cargo clippy -p velesdb-python --lib -- -D warnings` (clean), `cargo test --doc --package velesdb-core` (50 passed), `RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-core --no-deps --all-features` (clean — no broken intra-doc links), `cargo fmt --check`, and the guard scripts `check-ai-attribution.py`, `check-feature-claims.py`, `check-promise-contract.py`, `check-version-sync.py`, `check_prod_unwraps.py`, `check-todo-annotations.py`, `check-doc-freshness.py --guard stamp` (all pass).

Not run in this sandbox: the full workspace `cargo clippy --workspace` (fails to build `tauri-plugin-velesdb`'s `gdk-sys` build dependency — missing system GTK libs unrelated to this change), wasm/node-specific gates, and the benchmark/perf-smoke jobs (no behavior or hot-path change).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/guides/CONFIGURATION.md`, `CHANGELOG.md`, rustdoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `Drop`, `unsafe`, or SIMD dispatch path touched. `storage` is in the filename but this PR only changes config parsing/validation/reporting, not the storage engine itself.

## Additional Notes

Scope is deliberately narrower than all of #2087: `storage_mode` is a distinct, still-open decision (not `quantization::StorageMode`) and is intentionally left as-is, still reported as inert rather than deprecated. `[search]` and `[quantization]` wiring/deprecation are separate follow-ups per #2087's own scoping.