### PR TITLE
refactor(agent): dedup TTL far-end filtering across relation helpers

### DIFF
--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -1,10 +1,10 @@
 //! Shared helpers for agent memory subsystems (EPIC-010).
 //!
 //! Extracts common patterns used by `SemanticMemory`, `EpisodicMemory`, and
-//! `ProceduralMemory` to avoid code duplication across the three modules.
-//!
-//! These helpers are ready for adoption by memory submodules.
-//! Currently tested directly; callers will migrate in a follow-up.
+//! `ProceduralMemory` to avoid code duplication across the three modules. All
+//! three have adopted these helpers for their relation, TTL, and
+//! serialization plumbing; tests here cover the helpers directly, and the
+//! per-kind `*_tests.rs` suites cover them again through each public API.
 
 use crate::collection::Collection;
 use crate::{Database, DistanceMetric, Point};
@@ -670,6 +670,24 @@ pub(super) fn relate_memory_points(
     Ok(edge_id)
 }
 
+/// Drops edges whose far end — as picked out by `far_end` — is TTL-expired
+/// in the given subsystem.
+///
+/// `far_end` is `GraphEdge::target` for an outgoing edge or `GraphEdge::source`
+/// for an incoming one: the live endpoint is the one already known to the
+/// caller, so the filter always guards the *other* side.
+fn filter_live_far_end(
+    edges: Vec<crate::collection::graph::GraphEdge>,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+    far_end: fn(&crate::collection::graph::GraphEdge) -> u64,
+) -> Vec<crate::collection::graph::GraphEdge> {
+    edges
+        .into_iter()
+        .filter(|edge| !ttl.is_expired(kind, far_end(edge)))
+        .collect()
+}
+
 /// Returns the outgoing relation edges of a memory point, filtering out edges
 /// whose target is TTL-expired in the given subsystem.
 ///
@@ -687,11 +705,12 @@ pub(super) fn relations_of(
     kind: super::ttl::MemoryKind,
 ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
     let collection = get_collection(db, collection_name)?;
-    Ok(collection
-        .get_outgoing_edges(id)
-        .into_iter()
-        .filter(|edge| !ttl.is_expired(kind, edge.target()))
-        .collect())
+    Ok(filter_live_far_end(
+        collection.get_outgoing_edges(id),
+        ttl,
+        kind,
+        crate::collection::graph::GraphEdge::target,
+    ))
 }
 
 /// Bounded twin of [`relations_of`] (#1820): resolves at most `cap` stored
@@ -719,10 +738,12 @@ pub(super) fn relations_of_bounded(
     let collection = get_collection(db, collection_name)?;
     let (edges, total) = collection.get_outgoing_edges_bounded(id, cap);
     Ok(super::BoundedRelations {
-        edges: edges
-            .into_iter()
-            .filter(|edge| !ttl.is_expired(kind, edge.target()))
-            .collect(),
+        edges: filter_live_far_end(
+            edges,
+            ttl,
+            kind,
+            crate::collection::graph::GraphEdge::target,
+        ),
         truncated: total > cap,
     })
 }
@@ -747,11 +768,12 @@ pub(super) fn incoming_relations_of(
     kind: super::ttl::MemoryKind,
 ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
     let collection = get_collection(db, collection_name)?;
-    Ok(collection
-        .get_incoming_edges(id)
-        .into_iter()
-        .filter(|edge| !ttl.is_expired(kind, edge.source()))
-        .collect())
+    Ok(filter_live_far_end(
+        collection.get_incoming_edges(id),
+        ttl,
+        kind,
+        crate::collection::graph::GraphEdge::source,
+    ))
 }
 
 /// Bounded twin of [`incoming_relations_of`] — the incoming mirror of
@@ -773,10 +795,12 @@ pub(super) fn incoming_relations_of_bounded(
     let collection = get_collection(db, collection_name)?;
     let (edges, total) = collection.get_incoming_edges_bounded(id, cap);
     Ok(super::BoundedRelations {
-        edges: edges
-            .into_iter()
-            .filter(|edge| !ttl.is_expired(kind, edge.source()))
-            .collect(),
+        edges: filter_live_far_end(
+            edges,
+            ttl,
+            kind,
+            crate::collection::graph::GraphEdge::source,
+        ),
         truncated: total > cap,
     })
 }

--- a/crates/velesdb-core/src/agent/memory_helpers_tests.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers_tests.rs
@@ -106,6 +106,59 @@ fn rebuild_stored_ids_deduplicates() {
     assert!(ids.contains(&1));
 }
 
+// --- filter_live_far_end ---
+
+use crate::agent::ttl::{MemoryKind, MemoryTtl};
+use crate::collection::graph::GraphEdge;
+
+fn edge(id: u64, source: u64, target: u64) -> GraphEdge {
+    GraphEdge::new(id, source, target, "RELATES").expect("non-empty label")
+}
+
+#[test]
+fn filter_live_far_end_keeps_edges_whose_far_end_is_not_tracked() {
+    let ttl = MemoryTtl::new();
+    let edges = vec![edge(1, 10, 20), edge(2, 10, 21)];
+
+    let kept = filter_live_far_end(edges.clone(), &ttl, MemoryKind::Semantic, GraphEdge::target);
+
+    assert_eq!(kept, edges);
+}
+
+#[test]
+fn filter_live_far_end_drops_edges_whose_far_end_expired() {
+    let ttl = MemoryTtl::new();
+    ttl.set_expiry(MemoryKind::Semantic, 21, 0); // 0 <= now() => expired
+    let edges = vec![edge(1, 10, 20), edge(2, 10, 21)];
+
+    let kept = filter_live_far_end(edges, &ttl, MemoryKind::Semantic, GraphEdge::target);
+
+    assert_eq!(kept, vec![edge(1, 10, 20)]);
+}
+
+#[test]
+fn filter_live_far_end_checks_source_for_incoming_edges() {
+    let ttl = MemoryTtl::new();
+    ttl.set_expiry(MemoryKind::Semantic, 10, 0); // source of edge 1 expired
+    let edges = vec![edge(1, 10, 20), edge(2, 11, 20)];
+
+    let kept = filter_live_far_end(edges, &ttl, MemoryKind::Semantic, GraphEdge::source);
+
+    assert_eq!(kept, vec![edge(2, 11, 20)]);
+}
+
+#[test]
+fn filter_live_far_end_scopes_expiry_to_the_given_kind() {
+    let ttl = MemoryTtl::new();
+    // Expired under a different subsystem — must not affect Semantic's view.
+    ttl.set_expiry(MemoryKind::Episodic, 20, 0);
+    let edges = vec![edge(1, 10, 20)];
+
+    let kept = filter_live_far_end(edges.clone(), &ttl, MemoryKind::Semantic, GraphEdge::target);
+
+    assert_eq!(kept, edges);
+}
+
 // --- open_or_create_collection (requires persistence + tempdir) ---
 
 #[cfg(feature = "persistence")]


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop` (this PR does).

## Description

`crates/velesdb-core/src/agent/memory_helpers.rs` had four near-identical
relation accessors — `relations_of`, `incoming_relations_of`, and their
`_bounded` twins — each inlining the same "drop edges whose far endpoint is
TTL-expired" filter loop, differing only in which endpoint (`target()` vs
`source()`) the filter checks. `jscpd` flagged these as duplicate blocks.

Extracted a private `filter_live_far_end(edges, ttl, kind, far_end)` helper
parameterized by a `fn(&GraphEdge) -> u64` endpoint selector
(`GraphEdge::target` or `GraphEdge::source`), and updated all four callers to
use it. No public API, signature, or behavior change — same collection reads,
same filter predicate, same `BoundedRelations` construction.

Added direct unit tests for the new helper (keeps untracked edges, drops an
expired far end on each side, scopes expiry to the given `MemoryKind`)
alongside the existing integration coverage in `semantic_memory_tests`.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- New direct unit tests for `filter_live_far_end` (4 cases), plus existing
  coverage (`agent::semantic_memory_tests`, including
  `test_relations_hide_expired_endpoints`,
  `test_incoming_relations_filters_expired_source`, and the bounded-relations
  cases) which exercises all four callers.
- `cargo clippy -p velesdb-core --lib --tests --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo test -p velesdb-core --features persistence --lib -- --test-threads=1` — 5486 passed, 0 failed, 16 ignored
- `cargo test --doc --package velesdb-core` — 50 passed
- `cargo fmt --all -- --check` — clean

**Test Configuration:**
- OS: Linux
- Rust version: 1.90.0 (pinned MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed — internal, non-public helper)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Found via a routine duplication scan (`npx jscpd --min-tokens 50 --format rust crates/`), not tied to any open issue.
