### PR TITLE
test(persistence): exercise the adopted .vectors arena end to end

### DIFF
--- a/crates/velesdb-core/tests/vectors_format_roundtrip.rs
+++ b/crates/velesdb-core/tests/vectors_format_roundtrip.rs
@@ -1,4 +1,12 @@
-#![allow(clippy::cast_precision_loss)] // ids into f32 coordinates, deliberately
+#![cfg(feature = "persistence")]
+#![allow(clippy::cast_precision_loss)]
+// ids into f32 coordinates, deliberately
+
+// Without `persistence` there is no `Database`, no mapped arena and no
+// `.vectors` at all. Most files in this directory carry the same gate. It is
+// not decoration: `quality-deep.yml` runs `cargo miri test
+// --no-default-features -p velesdb-core` WITHOUT `--lib`, which compiles every
+// test target - so an ungated file breaks a job that only runs on Sundays.
 
 //! End-to-end coverage of `{basename}.vectors` across a real database lifecycle.
 //!
@@ -60,6 +68,18 @@ const ADOPTED: u64 = 64;
 const SMALL: u64 = 5;
 /// Enough new points to force the mapping to grow past its persisted capacity.
 const EXTRA: u64 = 32;
+
+// The size witness below reads "the file is larger than the payload it
+// declares". Capacity doubles on growth, so that holds only while the doubled
+// capacity OVERSHOOTS the final count: at EXTRA == ADOPTED the arena lands on
+// exactly 2x, and the witness would report "copied" on an arena that was in
+// fact adopted - a false negative carrying a confident message. The constraint
+// lives here, where changing a constant trips it, rather than in a sentence
+// nobody re-reads.
+const _: () = assert!(
+    EXTRA < ADOPTED,
+    "the adoption witness needs the doubled capacity to overshoot the final count"
+);
 
 fn make_vector(id: u64) -> Vec<f32> {
     (0..DIM)
@@ -145,6 +165,27 @@ fn payload(path: &Path) -> Vec<Vec<f32>> {
                 .collect()
         })
         .collect()
+}
+
+/// Every disposable arena file under `root`.
+///
+/// `ArenaHome::claim` names them `hnsw-{token}.arena`, so their presence is a
+/// public, on-disk witness that a graph really owns one — no `pub(crate)`
+/// access needed, and no property of the growth strategy inferred.
+fn disposable_arenas(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("test: read dir").flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "arena") {
+                found.push(path);
+            }
+        }
+    }
+    found
 }
 
 fn digest(path: &Path) -> u64 {
@@ -293,21 +334,25 @@ fn a_grown_arena_was_adopted_rather_than_copied() {
 #[test]
 fn dropping_a_collection_with_a_disposable_arena_keeps_its_vectors() {
     let dir = TempDir::new().expect("test: tempdir");
-    seed(&dir, 0..ADOPTED, StorageMode::SQ8);
+    seed(&dir, 0..SMALL, StorageMode::SQ8);
     let file = vectors_file(dir.path());
     let before = digest(&file);
 
-    {
-        let db = Database::open(dir.path()).expect("test: reopen");
-        let collection = db
-            .get_vector_collection("docs")
-            .expect("test: collection exists");
-        assert_eq!(
-            collection.len(),
-            usize::try_from(ADOPTED).expect("test: fits"),
-            "test: the fixture did not load"
-        );
-    }
+    let db = Database::open(dir.path()).expect("test: reopen");
+    let collection = db
+        .get_vector_collection("docs")
+        .expect("test: collection exists");
+    assert_eq!(
+        collection.len(),
+        usize::try_from(SMALL).expect("test: fits"),
+        "test: the fixture did not load"
+    );
+    assert!(
+        !disposable_arenas(dir.path()).is_empty(),
+        "test: no hnsw-*.arena exists, so this collection never owned a disposable \
+         arena and the drop hazard is never reached"
+    );
+    drop(db);
 
     assert!(
         file.exists(),
@@ -319,3 +364,12 @@ fn dropping_a_collection_with_a_disposable_arena_keeps_its_vectors() {
         "test: closing a collection rewrote its durable vector store"
     );
 }
+
+// Deliberately NOT asserted above: that the disposable arena file is gone after
+// the drop. It is not, and that is not a defect — `ArenaHome::sweep_stale`
+// exists precisely because "a crash or a kill skips Drop, so a collection
+// directory can carry arenas from a previous run", and the sweep runs at the
+// next collection open. An arena outliving its owner is an anticipated state,
+// so asserting its absence would pin a promise the design does not make. The
+// hazard this test guards is the other one: that the drop takes `.vectors`
+// with it.

--- a/crates/velesdb-core/tests/vectors_format_roundtrip.rs
+++ b/crates/velesdb-core/tests/vectors_format_roundtrip.rs
@@ -1,54 +1,41 @@
-//! A real database survives close and reopen with its `.vectors` untouched.
-//!
-//! # Why this exists as an integration test
-//!
-//! #2213 moved the `.vectors` payload to a page boundary and #2215 made the
-//! durable file *be* the graph's arena. Both shipped with unit tests written
-//! against `NativeHnsw` — by the same hand that wrote the change. What none of
-//! them exercised is the path a user takes: open a database, insert, close,
-//! reopen, and find the data where it was left.
-//!
-//! Two properties are asserted here that the unit tests structurally cannot,
-//! because they need a whole `Database` and a real directory:
-//!
-//! 1. **Opening a collection does not write to its `.vectors`.** The file is
-//!    hashed before and after a reopen. This is not tidiness: `velesdb-memory`'s
-//!    migration resume proves a source store unchanged by hashing exactly these
-//!    bytes, so a store that grew on open would make a correct resume look like
-//!    a corrupted one. The unit test for this drives `NativeHnsw` directly; a
-//!    collection open does considerably more.
-//!
-//! 2. **An adopted arena can grow and be saved without losing anything.** The
-//!    riskiest sequence #2215 introduced, and the one with no coverage at all:
-//!    reopen (which maps the durable file), insert past the persisted count so
-//!    the mapping must grow, save (which rewrites the header *in place* on a
-//!    file the arena still maps), then reopen again and read every vector back.
-//!    `File::create` on that path would have truncated the bytes the live
-//!    mapping still pointed at — a SIGBUS rather than a failed assertion, which
-//!    is why the dump branches instead of relying on a test to notice.
-//!
-//! # The count is not arbitrary
-//!
-//! Adoption is refused below `ContiguousVectors::MIN_ARENA_CAPACITY`, because
-//! an arena sized up to that floor would extend the file merely by opening it.
-//! A test running under the floor would take the copy path on both sides while
-//! looking like it exercised adoption, so the counts here clear it by a wide
-//! margin.
-//!
-//! **What this file cannot do is observe that adoption happened.**
-//! `ContiguousVectors::backing_path` is `pub(crate)`, and reaching for it from
-//! outside would mean widening a crate-internal accessor to satisfy a test —
-//! the wrong trade. The unit suite in `vectors_format_tests.rs` asserts the
-//! mapping directly and is where that belongs.
-//!
-//! These tests assert the properties a *user* can observe, which must hold on
-//! either path: the file survives, it is not written by an open, the header
-//! records what was persisted, and every vector reads back. If adoption
-//! silently stopped happening they would still pass — and they should, because
-//! nothing a user relies on would have broken. What they catch is the opposite
-//! and worse case: adoption happening and losing or corrupting data.
-
 #![allow(clippy::cast_precision_loss)] // ids into f32 coordinates, deliberately
+
+//! End-to-end coverage of `{basename}.vectors` across a real database lifecycle.
+//!
+//! # Why these assertions read the FILE and not the collection
+//!
+//! An earlier version of this file asserted through `Collection` — `len()` and
+//! a handful of `search()` probes — and could not fail. Measured: delete
+//! `native_hnsw.vectors` outright, reopen, and `len()` still answers 64 while
+//! `search()` still returns the right id. The gap recovery rebuilds the graph
+//! from `vectors.idx` and the WAL at open, so **no assertion reaching through
+//! the collection API observes `.vectors` at all**.
+//!
+//! Everything below therefore reads the file: its header, its payload bytes,
+//! and its size. That is the only surface on which a claim about this format
+//! can be made.
+//!
+//! # What each test is for
+//!
+//! 1. **Opening never writes.** Checked on both sides of the arena capacity
+//!    floor, because the regression that motivated this file came from the
+//!    side *below* it: adoption there would size the arena up to the floor and
+//!    extend the file, and `velesdb-memory`'s migration resume proves a source
+//!    store unchanged by hashing exactly these files.
+//! 2. **Growing an adopted arena persists every vector.** The sequence no
+//!    other test performs: reopen (which maps the file), insert past the
+//!    persisted count so the mapping must grow, save — which rewrites the
+//!    header *in place* on a file the arena still maps — then read every f32
+//!    back out of the file.
+//! 3. **The grown arena was adopted, not copied.** Without this the file above
+//!    could be exercising the copy path on both sides and prove nothing about
+//!    mapping. The witness is public even though `backing_path` is not: an
+//!    adopted arena doubles its capacity when it grows, so the file ends up
+//!    larger than the payload it declares, while the copy path writes an exact
+//!    fit.
+//! 4. **A disposable arena's owner never deletes the durable store.** Run under
+//!    `StorageMode::SQ8`, because `Full` never constructs an `ArenaHome` at all
+//!    and the assertion would pass without ever reaching the hazard.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -56,13 +43,23 @@ use std::path::{Path, PathBuf};
 
 use serde_json::json;
 use tempfile::TempDir;
-use velesdb_core::{Database, DistanceMetric, Point};
+use velesdb_core::{Database, DistanceMetric, Point, StorageMode};
 
-/// Comfortably above the arena capacity floor, so a reopen adopts the file.
-const POINTS: u64 = 64;
-/// Added after the first reopen, to force the mapped arena to grow.
-const EXTRA: u64 = 32;
+/// Payload offset of a v2 `.vectors`, mirrored from `graph_io.rs`.
+///
+/// Duplicated rather than imported because this is an integration test: it
+/// links the crate from outside, where the constant is `pub(crate)`. The header
+/// assertion below refuses any version but 2, so a format that moves this
+/// offset makes these tests fail loudly rather than read the wrong bytes.
+const DATA_OFFSET: u64 = 4096;
 const DIM: usize = 8;
+
+/// Comfortably above the arena capacity floor, so adoption applies.
+const ADOPTED: u64 = 64;
+/// Comfortably below it, so the copy path applies.
+const SMALL: u64 = 5;
+/// Enough new points to force the mapping to grow past its persisted capacity.
+const EXTRA: u64 = 32;
 
 fn make_vector(id: u64) -> Vec<f32> {
     (0..DIM)
@@ -82,140 +79,243 @@ fn points(range: std::ops::Range<u64>) -> Vec<Point> {
 /// hard-codes the path keeps passing when the layout moves, silently hashing a
 /// file that is no longer the one under test.
 fn vectors_file(root: &Path) -> PathBuf {
-    fn walk(dir: &Path, found: &mut Vec<PathBuf>) {
-        let Ok(entries) = std::fs::read_dir(dir) else {
-            return;
-        };
-        for entry in entries.flatten() {
+    let mut found = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("test: read dir").flatten() {
             let path = entry.path();
             if path.is_dir() {
-                walk(&path, found);
+                stack.push(path);
             } else if path.file_name().is_some_and(|n| n == "native_hnsw.vectors") {
                 found.push(path);
             }
         }
     }
-    let mut found = Vec::new();
-    walk(root, &mut found);
     assert_eq!(
         found.len(),
         1,
-        "expected exactly one native_hnsw.vectors under {}, found {found:?}",
+        "test: expected exactly one native_hnsw.vectors under {}, found {found:?}",
         root.display()
     );
-    found.pop().expect("checked non-empty")
+    found.pop().expect("test: checked non-empty just above")
 }
 
-fn digest(path: &Path) -> u64 {
-    let bytes = std::fs::read(path).expect("read .vectors");
-    let mut hasher = DefaultHasher::new();
-    bytes.hash(&mut hasher);
-    hasher.finish()
+/// `(count, dimension)` from the header, refusing any version but 2.
+///
+/// The version check is not ceremony: a v3 that moves a field would otherwise
+/// be decoded as if it were v2, and every assertion below would compare
+/// confidently against the wrong bytes.
+fn header(path: &Path) -> (u64, u32) {
+    let bytes = std::fs::read(path).expect("test: read .vectors");
+    assert!(
+        bytes.len() >= usize::try_from(DATA_OFFSET).expect("test: offset fits a usize"),
+        "test: file shorter than its own header region"
+    );
+    let version = u32::from_le_bytes(bytes[0..4].try_into().expect("test: 4 bytes"));
+    assert_eq!(version, 2, "test: these assertions decode v2 only");
+    let count = u64::from_le_bytes(bytes[4..12].try_into().expect("test: 8 bytes"));
+    let dimension = u32::from_le_bytes(bytes[12..16].try_into().expect("test: 4 bytes"));
+    (count, dimension)
 }
 
-/// The declared vector count in the `.vectors` header: version(4), count(8).
-fn declared_count(path: &Path) -> u64 {
-    let bytes = std::fs::read(path).expect("read .vectors");
-    u64::from_le_bytes(bytes[4..12].try_into().expect("count field"))
-}
-
-fn seed(dir: &TempDir, ids: std::ops::Range<u64>) {
-    let db = Database::open(dir.path()).expect("open database");
-    db.create_vector_collection("docs", DIM, DistanceMetric::Cosine)
-        .expect("create collection");
-    let collection = db.get_vector_collection("docs").expect("collection exists");
-    collection.upsert(points(ids)).expect("upsert");
-    collection.flush_full().expect("flush");
-}
-
-/// Ranked ids for a fixed query — the comparable the round trip preserves.
-fn ranking(db: &Database) -> Vec<u64> {
-    let collection = db.get_vector_collection("docs").expect("collection exists");
-    collection
-        .search(&make_vector(7), 10)
-        .expect("search")
-        .into_iter()
-        .map(|hit| hit.point.id)
+/// Every vector the file declares, decoded from its payload.
+///
+/// This is the assertion surface the collection API cannot provide. Reads
+/// exactly `count * dimension` values from `DATA_OFFSET`; anything the arena
+/// left beyond them is uncommitted capacity the reader is meant to ignore.
+fn payload(path: &Path) -> Vec<Vec<f32>> {
+    let (count, dimension) = header(path);
+    let bytes = std::fs::read(path).expect("test: read .vectors");
+    let dim = dimension as usize;
+    let base = usize::try_from(DATA_OFFSET).expect("test: offset fits a usize");
+    let stored = usize::try_from(count).expect("test: count fits a usize");
+    let needed = base + stored * dim * 4;
+    assert!(
+        bytes.len() >= needed,
+        "test: file holds {} bytes but its header declares {needed}",
+        bytes.len()
+    );
+    (0..stored)
+        .map(|v| {
+            (0..dim)
+                .map(|k| {
+                    let at = base + (v * dim + k) * 4;
+                    f32::from_le_bytes(bytes[at..at + 4].try_into().expect("test: 4 bytes"))
+                })
+                .collect()
+        })
         .collect()
 }
 
+fn digest(path: &Path) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    std::fs::read(path)
+        .expect("test: read .vectors")
+        .hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Creates a collection holding `ids`, then closes the database.
+fn seed(dir: &TempDir, ids: std::ops::Range<u64>, mode: StorageMode) {
+    let db = Database::open(dir.path()).expect("test: open database");
+    db.create_vector_collection_with_options("docs", DIM, DistanceMetric::Euclidean, mode)
+        .expect("test: create collection");
+    let collection = db
+        .get_vector_collection("docs")
+        .expect("test: collection exists");
+    collection.upsert(points(ids)).expect("test: upsert");
+    collection.flush_full().expect("test: flush");
+}
+
+/// Opening a collection must never write to its `.vectors`, on either side of
+/// the arena capacity floor.
+///
+/// Below the floor adoption is refused and the copy path runs; above it the
+/// file is mapped. Both must leave the bytes untouched. The regression this
+/// guards took out twenty-one `velesdb-memory` tests when adoption first
+/// shipped: its migration resume proves a source store unchanged by hashing
+/// these very files, so a store that grew on open made a correct resume look
+/// like a corrupted one.
 #[test]
-fn reopening_a_collection_does_not_touch_its_vectors_file() {
-    // Arrange
-    let dir = TempDir::new().expect("tempdir");
-    seed(&dir, 0..POINTS);
+fn opening_a_collection_never_writes_to_its_vectors_file() {
+    for count in [SMALL, ADOPTED] {
+        let dir = TempDir::new().expect("test: tempdir");
+        seed(&dir, 0..count, StorageMode::Full);
+        let file = vectors_file(dir.path());
+        let before = digest(&file);
+
+        {
+            let db = Database::open(dir.path()).expect("test: reopen");
+            let collection = db
+                .get_vector_collection("docs")
+                .expect("test: collection exists");
+            assert_eq!(
+                collection.len(),
+                usize::try_from(count).expect("test: count fits a usize"),
+                "test: the fixture did not load at {count} points"
+            );
+        }
+
+        assert_eq!(
+            digest(&file),
+            before,
+            "test: opening a collection wrote to its .vectors at {count} points"
+        );
+    }
+}
+
+/// Growing an adopted arena and saving persists every vector to the file.
+///
+/// This is the sequence `File::create` would have broken: the dump rewrites the
+/// header in place on a file the arena still maps, because truncating it would
+/// remove the pages the mapping points at. The failure mode there is a SIGBUS
+/// rather than an assertion, so what a test can do is prove the bytes are right
+/// afterwards — which is why every vector is read back out of the file rather
+/// than out of the collection.
+#[test]
+fn growing_an_adopted_arena_persists_every_vector_to_the_file() {
+    let dir = TempDir::new().expect("test: tempdir");
+    seed(&dir, 0..ADOPTED, StorageMode::Full);
     let file = vectors_file(dir.path());
-    let before = digest(&file);
+    assert_eq!(header(&file).0, ADOPTED, "test: the seed did not persist");
+
+    {
+        let db = Database::open(dir.path()).expect("test: reopen");
+        let collection = db
+            .get_vector_collection("docs")
+            .expect("test: collection exists");
+        collection
+            .upsert(points(ADOPTED..ADOPTED + EXTRA))
+            .expect("test: upsert past the persisted count");
+        collection.flush_full().expect("test: flush");
+    }
+
+    let total = ADOPTED + EXTRA;
     assert_eq!(
-        declared_count(&file),
-        POINTS,
-        "the dump must declare its rows"
+        header(&file).0,
+        total,
+        "test: the in-place header rewrite did not record the grown count"
     );
 
-    let db = Database::open(dir.path()).expect("reopen");
-    let expected = ranking(&db);
-    assert!(!expected.is_empty(), "the query must match something");
+    let stored = payload(&file);
+    assert_eq!(stored.len(), usize::try_from(total).expect("test: fits"));
+    for (id, vector) in stored.iter().enumerate() {
+        assert_eq!(
+            vector.as_slice(),
+            make_vector(id as u64).as_slice(),
+            "test: vector {id} did not survive the grow-and-save"
+        );
+    }
+}
 
-    // Act
-    drop(db);
+/// The grown arena was adopted, not copied.
+///
+/// Without this, the test above could be exercising the copy path on both sides
+/// and would prove nothing about mapping. `backing_path` is `pub(crate)` and
+/// out of reach here, but the consequence is public: an adopted arena doubles
+/// its capacity when it grows, so the file ends up **larger** than the payload
+/// it declares. The copy path writes an exact fit.
+#[test]
+fn a_grown_arena_was_adopted_rather_than_copied() {
+    let dir = TempDir::new().expect("test: tempdir");
+    seed(&dir, 0..ADOPTED, StorageMode::Full);
+    let file = vectors_file(dir.path());
 
-    // Assert: the file is still there, and byte-identical.
+    {
+        let db = Database::open(dir.path()).expect("test: reopen");
+        let collection = db
+            .get_vector_collection("docs")
+            .expect("test: collection exists");
+        collection
+            .upsert(points(ADOPTED..ADOPTED + EXTRA))
+            .expect("test: upsert");
+        collection.flush_full().expect("test: flush");
+    }
+
+    let (count, dimension) = header(&file);
+    let exact_fit = DATA_OFFSET + count * u64::from(dimension) * 4;
+    let actual = std::fs::metadata(&file).expect("test: stat").len();
+    assert!(
+        actual > exact_fit,
+        "test: the file is an exact fit ({actual} bytes) — the arena was copied, \
+         not adopted, so the mapped path this suite targets never ran"
+    );
+}
+
+/// A collection whose arena is disposable must still keep its durable store.
+///
+/// `ArenaHome::drop` removes its file unconditionally, and that is correct: the
+/// disposable arena is a cache. The hazard is pointing it at `.vectors`.
+///
+/// Run under `SQ8` on purpose. `Full` never constructs an `ArenaHome` at all,
+/// so the same assertion there passes without the hazard ever being reached —
+/// a green test about nothing.
+#[test]
+fn dropping_a_collection_with_a_disposable_arena_keeps_its_vectors() {
+    let dir = TempDir::new().expect("test: tempdir");
+    seed(&dir, 0..ADOPTED, StorageMode::SQ8);
+    let file = vectors_file(dir.path());
+    let before = digest(&file);
+
+    {
+        let db = Database::open(dir.path()).expect("test: reopen");
+        let collection = db
+            .get_vector_collection("docs")
+            .expect("test: collection exists");
+        assert_eq!(
+            collection.len(),
+            usize::try_from(ADOPTED).expect("test: fits"),
+            "test: the fixture did not load"
+        );
+    }
+
     assert!(
         file.exists(),
-        "closing a collection must never delete its durable vector store"
+        "test: closing a collection deleted its durable vector store"
     );
     assert_eq!(
         digest(&file),
         before,
-        "opening a collection wrote to its .vectors"
+        "test: closing a collection rewrote its durable vector store"
     );
-
-    // And it still reads back the same ranking.
-    let db = Database::open(dir.path()).expect("second reopen");
-    assert_eq!(
-        ranking(&db),
-        expected,
-        "the ranking must survive a round trip"
-    );
-}
-
-#[test]
-fn growing_an_adopted_arena_and_saving_keeps_every_vector() {
-    // Arrange: a persisted collection, then a reopen that maps the file.
-    let dir = TempDir::new().expect("tempdir");
-    seed(&dir, 0..POINTS);
-    let file = vectors_file(dir.path());
-    assert_eq!(declared_count(&file), POINTS);
-
-    // Act: insert past the persisted count, so the mapping has to grow, then
-    // save — which rewrites the header in place on the file it maps.
-    {
-        let db = Database::open(dir.path()).expect("reopen");
-        let collection = db.get_vector_collection("docs").expect("collection exists");
-        collection
-            .upsert(points(POINTS..POINTS + EXTRA))
-            .expect("upsert past the persisted count");
-        collection.flush_full().expect("flush");
-    }
-
-    // Assert: the header caught up, and every vector reads back.
-    assert_eq!(
-        declared_count(&file),
-        POINTS + EXTRA,
-        "the header must record the grown count"
-    );
-
-    let db = Database::open(dir.path()).expect("final reopen");
-    let collection = db.get_vector_collection("docs").expect("collection exists");
-    let expected_len = usize::try_from(POINTS + EXTRA).expect("test: the point count fits a usize");
-    assert_eq!(collection.len(), expected_len);
-
-    for id in [0, 7, POINTS - 1, POINTS, POINTS + EXTRA - 1] {
-        let hits = collection.search(&make_vector(id), 1).expect("search");
-        assert_eq!(
-            hits.first().map(|hit| hit.point.id),
-            Some(id),
-            "vector {id} did not survive growth through its own mapping"
-        );
-    }
 }

--- a/crates/velesdb-core/tests/vectors_format_roundtrip.rs
+++ b/crates/velesdb-core/tests/vectors_format_roundtrip.rs
@@ -1,0 +1,221 @@
+//! A real database survives close and reopen with its `.vectors` untouched.
+//!
+//! # Why this exists as an integration test
+//!
+//! #2213 moved the `.vectors` payload to a page boundary and #2215 made the
+//! durable file *be* the graph's arena. Both shipped with unit tests written
+//! against `NativeHnsw` — by the same hand that wrote the change. What none of
+//! them exercised is the path a user takes: open a database, insert, close,
+//! reopen, and find the data where it was left.
+//!
+//! Two properties are asserted here that the unit tests structurally cannot,
+//! because they need a whole `Database` and a real directory:
+//!
+//! 1. **Opening a collection does not write to its `.vectors`.** The file is
+//!    hashed before and after a reopen. This is not tidiness: `velesdb-memory`'s
+//!    migration resume proves a source store unchanged by hashing exactly these
+//!    bytes, so a store that grew on open would make a correct resume look like
+//!    a corrupted one. The unit test for this drives `NativeHnsw` directly; a
+//!    collection open does considerably more.
+//!
+//! 2. **An adopted arena can grow and be saved without losing anything.** The
+//!    riskiest sequence #2215 introduced, and the one with no coverage at all:
+//!    reopen (which maps the durable file), insert past the persisted count so
+//!    the mapping must grow, save (which rewrites the header *in place* on a
+//!    file the arena still maps), then reopen again and read every vector back.
+//!    `File::create` on that path would have truncated the bytes the live
+//!    mapping still pointed at — a SIGBUS rather than a failed assertion, which
+//!    is why the dump branches instead of relying on a test to notice.
+//!
+//! # The count is not arbitrary
+//!
+//! Adoption is refused below `ContiguousVectors::MIN_ARENA_CAPACITY`, because
+//! an arena sized up to that floor would extend the file merely by opening it.
+//! A test running under the floor would take the copy path on both sides while
+//! looking like it exercised adoption, so the counts here clear it by a wide
+//! margin.
+//!
+//! **What this file cannot do is observe that adoption happened.**
+//! `ContiguousVectors::backing_path` is `pub(crate)`, and reaching for it from
+//! outside would mean widening a crate-internal accessor to satisfy a test —
+//! the wrong trade. The unit suite in `vectors_format_tests.rs` asserts the
+//! mapping directly and is where that belongs.
+//!
+//! These tests assert the properties a *user* can observe, which must hold on
+//! either path: the file survives, it is not written by an open, the header
+//! records what was persisted, and every vector reads back. If adoption
+//! silently stopped happening they would still pass — and they should, because
+//! nothing a user relies on would have broken. What they catch is the opposite
+//! and worse case: adoption happening and losing or corrupting data.
+
+#![allow(clippy::cast_precision_loss)] // ids into f32 coordinates, deliberately
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+use tempfile::TempDir;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+/// Comfortably above the arena capacity floor, so a reopen adopts the file.
+const POINTS: u64 = 64;
+/// Added after the first reopen, to force the mapped arena to grow.
+const EXTRA: u64 = 32;
+const DIM: usize = 8;
+
+fn make_vector(id: u64) -> Vec<f32> {
+    (0..DIM)
+        .map(|i| ((id as f32) * 0.37 + (i as f32) * 0.11).sin())
+        .collect()
+}
+
+fn points(range: std::ops::Range<u64>) -> Vec<Point> {
+    range
+        .map(|id| Point::new(id, make_vector(id), Some(json!({ "id": id }))))
+        .collect()
+}
+
+/// Finds `native_hnsw.vectors` under the database directory.
+///
+/// Located by walking rather than by reconstructing the layout: a test that
+/// hard-codes the path keeps passing when the layout moves, silently hashing a
+/// file that is no longer the one under test.
+fn vectors_file(root: &Path) -> PathBuf {
+    fn walk(dir: &Path, found: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, found);
+            } else if path.file_name().is_some_and(|n| n == "native_hnsw.vectors") {
+                found.push(path);
+            }
+        }
+    }
+    let mut found = Vec::new();
+    walk(root, &mut found);
+    assert_eq!(
+        found.len(),
+        1,
+        "expected exactly one native_hnsw.vectors under {}, found {found:?}",
+        root.display()
+    );
+    found.pop().expect("checked non-empty")
+}
+
+fn digest(path: &Path) -> u64 {
+    let bytes = std::fs::read(path).expect("read .vectors");
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// The declared vector count in the `.vectors` header: version(4), count(8).
+fn declared_count(path: &Path) -> u64 {
+    let bytes = std::fs::read(path).expect("read .vectors");
+    u64::from_le_bytes(bytes[4..12].try_into().expect("count field"))
+}
+
+fn seed(dir: &TempDir, ids: std::ops::Range<u64>) {
+    let db = Database::open(dir.path()).expect("open database");
+    db.create_vector_collection("docs", DIM, DistanceMetric::Cosine)
+        .expect("create collection");
+    let collection = db.get_vector_collection("docs").expect("collection exists");
+    collection.upsert(points(ids)).expect("upsert");
+    collection.flush_full().expect("flush");
+}
+
+/// Ranked ids for a fixed query — the comparable the round trip preserves.
+fn ranking(db: &Database) -> Vec<u64> {
+    let collection = db.get_vector_collection("docs").expect("collection exists");
+    collection
+        .search(&make_vector(7), 10)
+        .expect("search")
+        .into_iter()
+        .map(|hit| hit.point.id)
+        .collect()
+}
+
+#[test]
+fn reopening_a_collection_does_not_touch_its_vectors_file() {
+    // Arrange
+    let dir = TempDir::new().expect("tempdir");
+    seed(&dir, 0..POINTS);
+    let file = vectors_file(dir.path());
+    let before = digest(&file);
+    assert_eq!(
+        declared_count(&file),
+        POINTS,
+        "the dump must declare its rows"
+    );
+
+    let db = Database::open(dir.path()).expect("reopen");
+    let expected = ranking(&db);
+    assert!(!expected.is_empty(), "the query must match something");
+
+    // Act
+    drop(db);
+
+    // Assert: the file is still there, and byte-identical.
+    assert!(
+        file.exists(),
+        "closing a collection must never delete its durable vector store"
+    );
+    assert_eq!(
+        digest(&file),
+        before,
+        "opening a collection wrote to its .vectors"
+    );
+
+    // And it still reads back the same ranking.
+    let db = Database::open(dir.path()).expect("second reopen");
+    assert_eq!(
+        ranking(&db),
+        expected,
+        "the ranking must survive a round trip"
+    );
+}
+
+#[test]
+fn growing_an_adopted_arena_and_saving_keeps_every_vector() {
+    // Arrange: a persisted collection, then a reopen that maps the file.
+    let dir = TempDir::new().expect("tempdir");
+    seed(&dir, 0..POINTS);
+    let file = vectors_file(dir.path());
+    assert_eq!(declared_count(&file), POINTS);
+
+    // Act: insert past the persisted count, so the mapping has to grow, then
+    // save — which rewrites the header in place on the file it maps.
+    {
+        let db = Database::open(dir.path()).expect("reopen");
+        let collection = db.get_vector_collection("docs").expect("collection exists");
+        collection
+            .upsert(points(POINTS..POINTS + EXTRA))
+            .expect("upsert past the persisted count");
+        collection.flush_full().expect("flush");
+    }
+
+    // Assert: the header caught up, and every vector reads back.
+    assert_eq!(
+        declared_count(&file),
+        POINTS + EXTRA,
+        "the header must record the grown count"
+    );
+
+    let db = Database::open(dir.path()).expect("final reopen");
+    let collection = db.get_vector_collection("docs").expect("collection exists");
+    let expected_len = usize::try_from(POINTS + EXTRA).expect("test: the point count fits a usize");
+    assert_eq!(collection.len(), expected_len);
+
+    for id in [0, 7, POINTS - 1, POINTS, POINTS + EXTRA - 1] {
+        let hits = collection.search(&make_vector(id), 1).expect("search");
+        assert_eq!(
+            hits.first().map(|hit| hit.point.id),
+            Some(id),
+            "vector {id} did not survive growth through its own mapping"
+        );
+    }
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`test/*` → targets `develop`. ✅

## Description

Every assurance that #2215 is safe came from unit tests written alongside the change itself. This covers the sequence a real database performs, and that no test did:

**create → close → reopen** (which maps the durable file as the arena) → **insert past the persisted count** so the mapping has to grow → **save** → **reopen** → **read every vector back**.

That is the path where `File::create` would have truncated the bytes a live mapping still pointed at. The failure mode there is a **SIGBUS rather than an assertion**, so no test could catch it after the fact; what a test *can* do is prove the sequence completes and the data survives.

The fixture goes through a real `Database` on the public API, not a `NativeHnsw` built by hand — it exercises the wiring a user reaches, not the layer the change was written at.

## Two cases

**`reopening_a_collection_does_not_touch_its_vectors_file`** hashes `native_hnsw.vectors` before and after an open, and asserts equality.

Opening a collection must never write to it. That is not tidiness: `velesdb-memory`'s migration resume proves a source store unchanged by hashing exactly these files, and **twenty-one of its tests failed** when adoption first shipped without that guarantee.

**`growing_an_adopted_arena_and_saving_keeps_every_vector`** is the one that bites.

Proven by sabotage rather than asserted: removing the in-place header rewrite from the adopted dump path leaves the persisted count stuck at the pre-growth value, and the test fails naming the gap. Restored afterwards, and `git status` confirms the production file is untouched by this PR.

## Type of Change

- [x] 🧪 Test coverage

## How Has This Been Tested?

```
test reopening_a_collection_does_not_touch_its_vectors_file ... ok
test growing_an_adopted_arena_and_saving_keeps_every_vector ... ok
test result: ok. 2 passed; 0 failed
```

Gates run with the repository's own commands, not convenient ones:

- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` — clean
- `python3 scripts/check-drop-tightening.py` — PASSED
- `cargo fmt --check` — clean

Three clippy findings were fixed rather than silenced along the way, including a `u64 → usize` cast made explicit with `try_from` instead of an `allow`.

## Why this exists

`.vectors` v2 and the arena adoption changed the on-disk format and made the durable file the live arena, with one-way compatibility. Both landed with thorough unit tests — all written by the same hand that wrote the change. This is the first coverage of the whole round trip through the public surface, and it is what makes a 6.1.0 release a decision rather than a bet.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
