### PR TITLE
ci(tooling): replay the CI gates locally by reading them from the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,13 @@ jobs:
       - name: Test the deferred-removal guard
         run: python3 -m unittest scripts.tests.test_check_deferred_removals
 
+      # `local-ci.sh` n'est pas lance ici — il REJOUE ce job, l'executer dedans
+      # serait circulaire. Sa suite, elle, doit tourner : elle epingle deux
+      # defauts qu'il a deja eus, dont un faux vert (zero etape traitee
+      # rapportee comme un succes).
+      - name: Test the local gate replayer
+        run: python3 -m unittest scripts.tests.test_local_ci
+
       - name: Test feature-claims audit script
         run: python3 -m unittest scripts.tests.test_check_feature_claims
 

--- a/.github/workflows/gate-contracts.yml
+++ b/.github/workflows/gate-contracts.yml
@@ -30,6 +30,13 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
+      # `scripts/local-ci.sh` reads the workflow with PyYAML, and setup-python
+      # ships a bare interpreter, so its suite died on ModuleNotFoundError --
+      # eight opaque failures for one absent wheel. Marking those tests skipped
+      # would have been the cheaper fix and the wrong one: a suite that skips
+      # in CI is a suite CI does not run.
+      - name: Install the guard suites' Python dependencies
+        run: python -m pip install --disable-pip-version-check pyyaml==6.0.3
       - name: Run the guard contract suites
         run: python -m unittest discover -s scripts/tests -p "test_*.py" -t . -v
 

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Rejoue localement les portes que la CI exécute — en les LISANT dans ci.yml.
+#
+# POURQUOI DÉRIVER PLUTÔT QUE RECOPIER
+# ------------------------------------
+# Une liste de commandes recopiée à la main dérive de la CI, et la dérive est
+# silencieuse : elle se manifeste par une porte locale verte suivie d'une CI
+# rouge. C'est arrivé — `cargo clippy -p velesdb-core --lib` passait pendant que
+# la CI, qui lance `--workspace --all-targets`, compilait le code de TEST et
+# refusait. Ce script lit donc les `run:` du workflow ; il ne les connaît pas.
+#
+# Une étape que ce script ne peut pas rejouer est ANNONCÉE, jamais omise en
+# silence : une porte sautée sans le dire vaut moins qu'une porte absente.
+set -uo pipefail
+
+# Surchargeable pour que la suite puisse pointer un workflow synthetique et
+# prouver que la liste des portes est DERIVEE, pas recopiee.
+WORKFLOW="${WORKFLOW:-.github/workflows/ci.yml}"
+JOBS="${JOBS:-lint}"
+LIST_ONLY=0
+[ "${1:-}" = "--list" ] && LIST_ONLY=1
+
+[ -f "$WORKFLOW" ] || { echo "ERREUR: $WORKFLOW introuvable — lancer depuis la racine du dépôt" >&2; exit 2; }
+
+steps_json=$(python3 - "$WORKFLOW" "$JOBS" <<'PY'
+import json, sys, yaml
+wf, jobs = sys.argv[1], sys.argv[2].split(",")
+doc = yaml.safe_load(open(wf))
+out = []
+for job in jobs:
+    spec = (doc.get("jobs") or {}).get(job)
+    if spec is None:
+        print(f"ERREUR: job '{job}' absent de {wf}", file=sys.stderr); sys.exit(2)
+    for st in spec.get("steps", []):
+        run = st.get("run")
+        if run is None:
+            continue
+        # YAML rend `run: true` comme un booleen ; sans coercition le lecteur
+        # plante et — bien pire — la boucle appelante traite zero etape en
+        # silence tout en annoncant un succes.
+        run = run if isinstance(run, str) else str(run)
+        out.append({"job": job, "name": st.get("name", "(sans nom)"), "run": run})
+json.dump(out, sys.stdout)
+PY
+) || exit 2
+
+# Ce qu'un poste de travail ne peut pas rejouer : l'infrastructure du runner.
+skippable='GITHUB_|RUNNER_|apt-get|actions/|\$\{\{'
+
+total=0; ran=0; failed=0; skipped=0
+declare -a failures=()
+
+while IFS=$'\t' read -r job name run; do
+  total=$((total+1))
+  cmd=$(printf '%s' "$run" | base64 -d)
+  if printf '%s' "$cmd" | grep -qE "$skippable"; then
+    skipped=$((skipped+1))
+    printf '  ⤼ SAUTÉE  [%s] %s\n     (infrastructure du runner, non rejouable localement)\n' "$job" "$name"
+    continue
+  fi
+  if [ "$LIST_ONLY" = "1" ]; then
+    printf '  · [%s] %s\n' "$job" "$name"
+    continue
+  fi
+  printf '  ▶ %s ... ' "$name"
+  if out=$(bash -c "$cmd" 2>&1); then
+    ran=$((ran+1)); printf 'ok\n'
+  else
+    failed=$((failed+1)); failures+=("$name")
+    printf 'ÉCHEC\n'
+    printf '%s\n' "$out" | tail -15 | sed 's/^/       /'
+  fi
+done < <(printf '%s' "$steps_json" | python3 -c '
+import base64, json, sys
+# base64 pour la commande : un aller-retour par sequences d echappement
+# transforme les continuations de ligne `\` en `\`+`n` litteral, et le shell
+# recoit un argument `n`. Mesure faite — le gate rendait un FAUX ROUGE sur
+# clippy, ce qui est la facon la plus sure de faire desactiver une porte.
+for s in json.load(sys.stdin):
+    print("\t".join([s["job"], s["name"], base64.b64encode(s["run"].encode()).decode()]))
+')
+
+echo
+if [ "$LIST_ONLY" = "1" ]; then
+  if [ "$total" -eq 0 ]; then
+    echo "ERREUR: aucune étape lue dans $WORKFLOW (job(s): $JOBS)" >&2
+    exit 2
+  fi
+  echo "$total étape(s) déclarée(s), $skipped non rejouable(s) localement."
+  exit 0
+fi
+# Un gate qui annonce un succes sans avoir rien execute est pire qu'un gate
+# absent : l'operateur croit avoir verifie. Ce cas s'est produit — le lecteur
+# plantait sur une valeur inattendue et la boucle tournait a vide en rapportant
+# « toutes les portes passent ». Zero etape traitee est desormais une ERREUR.
+if [ "$total" -eq 0 ]; then
+  echo "ERREUR: aucune étape lue dans $WORKFLOW (job(s): $JOBS) — refus de rapporter un succès qui n'a rien vérifié" >&2
+  exit 2
+fi
+echo "Portes rejouées: $ran — échecs: $failed — non rejouables: $skipped (sur $total déclarées)"
+if [ "$failed" -gt 0 ]; then
+  printf 'ÉCHOUÉ: %s\n' "${failures[*]}" >&2
+  exit 1
+fi
+echo "Toutes les portes rejouables passent. Les $skipped autres ne sont vérifiées QUE par la CI."
+exit 0

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -28,6 +28,16 @@ LIST_ONLY=0
 
 [ -f "$WORKFLOW" ] || { echo "ERROR: $WORKFLOW not found - run from the repository root" >&2; exit 2; }
 
+# PyYAML reads the workflow. Hand-rolling that parser would be a reader able to
+# mis-understand the very file this script exists to trust, so the dependency
+# stays - but its absence is ANNOUNCED. It used to surface as a Python
+# traceback: the right exit code carrying no instruction, on a machine that
+# needed one `pip install`. Eight opaque failures in CI came from exactly that.
+python3 -c 'import yaml' 2>/dev/null || {
+  echo "ERROR: PyYAML is required to read $WORKFLOW - install it with: python3 -m pip install pyyaml" >&2
+  exit 2
+}
+
 steps_json=$(python3 - "$WORKFLOW" "$JOBS" <<'PY'
 import json, sys, yaml
 wf, jobs = sys.argv[1], sys.argv[2].split(",")
@@ -49,7 +59,7 @@ for job in jobs:
             print(f"ERROR: non-string `run:` in step {st.get('name','(unnamed)')!r} "
                   f"of job {job!r} - malformed workflow", file=sys.stderr)
             sys.exit(2)
-        out.append({"job": job, "name": st.get("name", "(sans nom)"), "run": run})
+        out.append({"job": job, "name": st.get("name", "(unnamed)"), "run": run})
 json.dump(out, sys.stdout)
 PY
 ) || exit 2
@@ -96,10 +106,10 @@ while IFS=$'\t' read -r job name run; do
   fi
 done < <(printf '%s' "$steps_json" | python3 -c '
 import base64, json, sys
-# base64 pour la commande : un aller-retour par sequences d echappement
-# transforme les continuations de ligne `\` en `\`+`n` litteral, et le shell
-# recoit un argument `n`. Mesure faite — le gate rendait un FAUX ROUGE sur
-# clippy, ce qui est la facon la plus sure de faire desactiver une porte.
+# base64 for the command: a round trip through escape sequences turns a
+# trailing line continuation into a literal backslash + `n`, and the shell then
+# receives an argument `n`. Measured - the gate rendered a FALSE RED on clippy,
+# which is the surest way to get a gate switched off.
 for s in json.load(sys.stdin):
     print("\t".join([s["job"], s["name"], base64.b64encode(s["run"].encode()).decode()]))
 ')
@@ -113,10 +123,10 @@ if [ "$LIST_ONLY" = "1" ]; then
   echo "$total step(s) declared, $skipped not replayable locally."
   exit 0
 fi
-# Un gate qui annonce un succes sans avoir rien execute est pire qu'un gate
-# absent : l'operateur croit avoir verifie. Ce cas s'est produit — le lecteur
-# plantait sur une valeur inattendue et la boucle tournait a vide en rapportant
-# « toutes les portes passent ». Zero etape traitee est desormais une ERREUR.
+# A gate that announces a pass without having executed anything is worse than
+# an absent gate: the operator believes they verified. This happened - the
+# reader crashed on an unexpected value, the loop ran empty, and it reported
+# "every gate passes". Zero steps processed is an ERROR now.
 if [ "$total" -eq 0 ]; then
   echo "ERROR: no steps read from $WORKFLOW (job(s): $JOBS) - refusing to report a pass that verified nothing" >&2
   exit 2

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,26 +1,32 @@
 #!/usr/bin/env bash
-# Rejoue localement les portes que la CI exécute — en les LISANT dans ci.yml.
+# Replays the gates CI runs, by READING them from the workflow.
 #
-# POURQUOI DÉRIVER PLUTÔT QUE RECOPIER
-# ------------------------------------
-# Une liste de commandes recopiée à la main dérive de la CI, et la dérive est
-# silencieuse : elle se manifeste par une porte locale verte suivie d'une CI
-# rouge. C'est arrivé — `cargo clippy -p velesdb-core --lib` passait pendant que
-# la CI, qui lance `--workspace --all-targets`, compilait le code de TEST et
-# refusait. Ce script lit donc les `run:` du workflow ; il ne les connaît pas.
+# WHY DERIVED RATHER THAN COPIED
+# ------------------------------
+# A hand-copied list of commands drifts from CI, and the drift is silent: it
+# shows up as a green local gate followed by a red CI. That happened —
+# `cargo clippy -p velesdb-core --lib` passed while CI, which runs
+# `--workspace --all-targets`, compiled the TEST code and refused. So this
+# script reads the workflow's `run:` blocks; it does not know them.
 #
-# Une étape que ce script ne peut pas rejouer est ANNONCÉE, jamais omise en
-# silence : une porte sautée sans le dire vaut moins qu'une porte absente.
+# A step it cannot replay is ANNOUNCED, never dropped in silence: a gate
+# skipped without saying so is worth less than a gate that is absent, because
+# the operator believes it ran.
+#
+# JOBS defaults to every gate job, not just `lint`. The first version replayed
+# `lint` alone and reported all-green on a tree that CI then failed on
+# `hygiene` and `gate-contracts` — the very narrowness this tool exists to
+# remove, reproduced inside it.
 set -uo pipefail
 
-# Surchargeable pour que la suite puisse pointer un workflow synthetique et
-# prouver que la liste des portes est DERIVEE, pas recopiee.
+# Overridable so the suite can point at a synthetic workflow and prove the
+# gate list is DERIVED rather than copied.
 WORKFLOW="${WORKFLOW:-.github/workflows/ci.yml}"
-JOBS="${JOBS:-lint}"
+JOBS="${JOBS:-lint,hygiene}"
 LIST_ONLY=0
 [ "${1:-}" = "--list" ] && LIST_ONLY=1
 
-[ -f "$WORKFLOW" ] || { echo "ERREUR: $WORKFLOW introuvable — lancer depuis la racine du dépôt" >&2; exit 2; }
+[ -f "$WORKFLOW" ] || { echo "ERROR: $WORKFLOW not found - run from the repository root" >&2; exit 2; }
 
 steps_json=$(python3 - "$WORKFLOW" "$JOBS" <<'PY'
 import json, sys, yaml
@@ -30,24 +36,28 @@ out = []
 for job in jobs:
     spec = (doc.get("jobs") or {}).get(job)
     if spec is None:
-        print(f"ERREUR: job '{job}' absent de {wf}", file=sys.stderr); sys.exit(2)
+        print(f"ERROR: job '{job}' not found in {wf}", file=sys.stderr); sys.exit(2)
     for st in spec.get("steps", []):
         run = st.get("run")
         if run is None:
             continue
-        # YAML rend `run: true` comme un booleen ; sans coercition le lecteur
-        # plante et — bien pire — la boucle appelante traite zero etape en
-        # silence tout en annoncant un succes.
-        run = run if isinstance(run, str) else str(run)
+        # YAML reads `run: true` as a boolean. Coercing it produced "True",
+        # which is not a command — the gate then reported a failure it had
+        # invented. A non-string `run:` is a malformed workflow, so say so
+        # instead of inventing a verdict about it.
+        if not isinstance(run, str):
+            print(f"ERROR: non-string `run:` in step {st.get('name','(unnamed)')!r} "
+                  f"of job {job!r} - malformed workflow", file=sys.stderr)
+            sys.exit(2)
         out.append({"job": job, "name": st.get("name", "(sans nom)"), "run": run})
 json.dump(out, sys.stdout)
 PY
 ) || exit 2
 
-# Ce qu'un poste de travail ne peut pas rejouer : l'infrastructure du runner.
+# What a workstation cannot replay: the runner's own infrastructure.
 skippable='GITHUB_|RUNNER_|apt-get|actions/|\$\{\{'
 
-total=0; ran=0; failed=0; skipped=0
+total=0; ran=0; failed=0; skipped=0; missing=0
 declare -a failures=()
 
 while IFS=$'\t' read -r job name run; do
@@ -55,7 +65,7 @@ while IFS=$'\t' read -r job name run; do
   cmd=$(printf '%s' "$run" | base64 -d)
   if printf '%s' "$cmd" | grep -qE "$skippable"; then
     skipped=$((skipped+1))
-    printf '  ⤼ SAUTÉE  [%s] %s\n     (infrastructure du runner, non rejouable localement)\n' "$job" "$name"
+    printf '  SKIPPED  [%s] %s\n     (runner infrastructure, not replayable locally)\n' "$job" "$name"
     continue
   fi
   if [ "$LIST_ONLY" = "1" ]; then
@@ -63,11 +73,25 @@ while IFS=$'\t' read -r job name run; do
     continue
   fi
   printf '  ▶ %s ... ' "$name"
-  if out=$(bash -c "$cmd" 2>&1); then
+  out=$(bash -c "$cmd" 2>&1); rc=$?
+  if [ "$rc" -eq 0 ]; then
     ran=$((ran+1)); printf 'ok\n'
+  elif [ "$rc" -eq 127 ] || printf '%s' "$out" | grep -qiE 'command not found|no such command|no such file or directory: [a-z]|is not installed'; then
+    # A tool this machine does not have is NOT a gate that refused. Reporting
+    # it as a failure is how a gate starts crying wolf, and a gate that cries
+    # wolf gets ignored - then switched off. Say what is missing instead.
+    #
+    # The pattern list is plural because each launcher phrases it differently:
+    # a shell says "command not found" and exits 127, while `cargo machete`
+    # says "no such command" and exits 101. The first version knew only the
+    # shell's wording and reported cargo-machete as a FAILING GATE on a clean
+    # tree - the exact false red this branch exists to prevent.
+    missing=$((missing+1))
+    printf 'TOOL MISSING\n'
+    printf '%s\n' "$out" | head -2 | sed 's/^/       /'
   else
     failed=$((failed+1)); failures+=("$name")
-    printf 'ÉCHEC\n'
+    printf 'FAILED\n'
     printf '%s\n' "$out" | tail -15 | sed 's/^/       /'
   fi
 done < <(printf '%s' "$steps_json" | python3 -c '
@@ -83,10 +107,10 @@ for s in json.load(sys.stdin):
 echo
 if [ "$LIST_ONLY" = "1" ]; then
   if [ "$total" -eq 0 ]; then
-    echo "ERREUR: aucune étape lue dans $WORKFLOW (job(s): $JOBS)" >&2
+    echo "ERROR: no steps read from $WORKFLOW (job(s): $JOBS)" >&2
     exit 2
   fi
-  echo "$total étape(s) déclarée(s), $skipped non rejouable(s) localement."
+  echo "$total step(s) declared, $skipped not replayable locally."
   exit 0
 fi
 # Un gate qui annonce un succes sans avoir rien execute est pire qu'un gate
@@ -94,13 +118,13 @@ fi
 # plantait sur une valeur inattendue et la boucle tournait a vide en rapportant
 # « toutes les portes passent ». Zero etape traitee est desormais une ERREUR.
 if [ "$total" -eq 0 ]; then
-  echo "ERREUR: aucune étape lue dans $WORKFLOW (job(s): $JOBS) — refus de rapporter un succès qui n'a rien vérifié" >&2
+  echo "ERROR: no steps read from $WORKFLOW (job(s): $JOBS) - refusing to report a pass that verified nothing" >&2
   exit 2
 fi
-echo "Portes rejouées: $ran — échecs: $failed — non rejouables: $skipped (sur $total déclarées)"
+echo "Gates replayed: $ran - failed: $failed - tool missing: $missing - runner-only: $skipped (of $total declared)"
 if [ "$failed" -gt 0 ]; then
-  printf 'ÉCHOUÉ: %s\n' "${failures[*]}" >&2
+  printf 'FAILED: %s\n' "${failures[*]}" >&2
   exit 1
 fi
-echo "Toutes les portes rejouables passent. Les $skipped autres ne sont vérifiées QUE par la CI."
+echo "Every gate this machine could run passes. $skipped runner-only and $missing missing-tool gates are checked ONLY by CI."
 exit 0

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -17,11 +17,15 @@ the merge button stays green, and it is the same class of defect as
 So the invariant is mechanical, not a checklist: every job in ``needs`` is
 either read by the chain or listed in ``CHAIN_EXEMPT`` with its reason.
 
-Deliberately regex-based, not PyYAML: ``gate-contracts.yml`` runs these
-suites with a bare ``actions/setup-python`` and installs nothing, so a
-third-party import here would be an ImportError in CI — a guard that cannot
-run. The parsers are unit-tested RED-then-GREEN on synthetic workflow text
-below before being pointed at the real file.
+Deliberately regex-based, not PyYAML. ``gate-contracts.yml`` does now install
+one pinned wheel, for ``test_local_ci``'s workflow reader — but this suite is
+the guard that decides whether every OTHER guard can refuse, so it stays
+buildable from the standard library alone. An import here would put the
+meta-guard behind a PyPI fetch: an outage would then read as a red gate on a
+clean tree, which is how this repository's npm gate came to be rewritten
+(``gate-contracts.yml``, ``npm-audit``). The parsers are unit-tested
+RED-then-GREEN on synthetic workflow text below before being pointed at the
+real file.
 """
 
 from __future__ import annotations

--- a/scripts/tests/test_local_ci.py
+++ b/scripts/tests/test_local_ci.py
@@ -150,6 +150,32 @@ class MissingToolTests(unittest.TestCase):
             self.assertIn("TOOL MISSING", result.stdout)
 
 
+class DependencyTests(unittest.TestCase):
+    """A missing PyYAML is announced, not surfaced as a traceback."""
+
+    def test_a_missing_pyyaml_names_the_install_command(self) -> None:
+        # Found in CI: setup-python ships a bare interpreter, so every
+        # invocation died on ModuleNotFoundError. The exit code was already
+        # right; the message was not, and an operator cannot act on a stack
+        # trace. Shadowing the module reproduces the absence on a machine that
+        # HAS it -- `test_a_gate_only_the_workflow_knows_about_is_listed` is
+        # the control: same invocation, no shadow, exit 0.
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "yaml.py").write_text(
+                "raise ImportError('shadowed by the test')", encoding="utf-8"
+            )
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("Any gate", "'echo ok'"), encoding="utf-8")
+            env = dict(os.environ, WORKFLOW=str(wf), JOBS="lint", PYTHONPATH=tmp)
+            result = subprocess.run(
+                [str(SCRIPT), "--list"], capture_output=True, text=True,
+                cwd=REPO_ROOT, env=env,
+            )
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("pip install pyyaml", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+
 class EscapingTests(unittest.TestCase):
     """The bug this script shipped with, pinned so it cannot return."""
 

--- a/scripts/tests/test_local_ci.py
+++ b/scripts/tests/test_local_ci.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/local-ci.sh.
+
+The script exists because a hand-copied list of gate commands drifts from the
+workflow, and the drift is silent: it shows up as a green local gate followed by
+a red CI. So the property worth testing is not that it runs — it is that the
+list it runs is **derived** from the workflow rather than baked in.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "local-ci.sh"
+
+
+def run(workflow: Path | None, *args: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    if workflow is not None:
+        env["WORKFLOW"] = str(workflow)
+    return subprocess.run(
+        [str(SCRIPT), *args], capture_output=True, text=True, cwd=REPO_ROOT, env=env
+    )
+
+
+def workflow_with(step_name: str, run_line: str, extra: str = "") -> str:
+    return textwrap.dedent(f"""\
+        name: synthetic
+        jobs:
+          lint:
+            steps:
+              - name: {step_name}
+                run: {run_line}
+        {extra}""")
+
+
+class DerivationTests(unittest.TestCase):
+    """A gate added to the workflow appears without touching the script."""
+
+    def test_a_gate_only_the_workflow_knows_about_is_listed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("Gate nobody hard-coded", "true"), encoding="utf-8")
+            result = run(wf, "--list")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Gate nobody hard-coded", result.stdout)
+
+    def test_a_runner_only_step_is_reported_rather_than_omitted(self) -> None:
+        # A gate skipped in silence is worth less than a gate that is absent:
+        # the operator believes it ran.
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("Needs the runner", "echo $GITHUB_SHA"), encoding="utf-8")
+            result = run(wf, "--list")
+            self.assertIn("SAUTÉE", result.stdout)
+            self.assertIn("Needs the runner", result.stdout)
+
+
+class RefusalTests(unittest.TestCase):
+    """It fails loudly rather than reporting a pass it never established."""
+
+    def test_a_failing_gate_makes_the_script_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("Gate that fails", "false"), encoding="utf-8")
+            result = run(wf)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Gate that fails", result.stderr)
+
+    def test_a_missing_workflow_answers_2_not_1(self) -> None:
+        # 2 is "cannot read", 1 is "refused". A tree this cannot read must not
+        # wear the exit code of a refusal it never made.
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run(Path(tmp) / "absent.yml")
+            self.assertEqual(result.returncode, 2)
+
+    def test_an_unknown_job_answers_2(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("x", "true"), encoding="utf-8")
+            env = dict(os.environ, WORKFLOW=str(wf), JOBS="does-not-exist")
+            result = subprocess.run(
+                [str(SCRIPT), "--list"], capture_output=True, text=True,
+                cwd=REPO_ROOT, env=env,
+            )
+            self.assertEqual(result.returncode, 2)
+
+
+class EmptyRunTests(unittest.TestCase):
+    """Zero steps executed must never look like a pass."""
+
+    def test_a_workflow_with_no_replayable_steps_answers_2(self) -> None:
+        # Found by this very suite: an unexpected value crashed the reader, the
+        # loop processed zero steps, and the script reported "all gates pass".
+        # An operator would have believed the gates ran. Zero is now an error.
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(
+                "name: synthetic\njobs:\n  lint:\n    steps:\n      - uses: actions/checkout@v4\n",
+                encoding="utf-8",
+            )
+            result = run(wf)
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("aucune étape", result.stderr)
+
+    def test_a_boolean_run_value_does_not_silently_empty_the_run(self) -> None:
+        # `run: true` is parsed by YAML as a boolean, not the string "true".
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("Boolean run", "true"), encoding="utf-8")
+            result = run(wf)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("Portes rejouées: 1", result.stdout)
+
+
+class EscapingTests(unittest.TestCase):
+    """The bug this script shipped with, pinned so it cannot return."""
+
+    def test_a_line_continuation_survives_the_round_trip(self) -> None:
+        # Encoding the command through escape sequences turned a trailing `\`
+        # into a literal `\` + `n`, and the shell received an argument `n`.
+        # That produced a FALSE RED on clippy — the surest way to get a gate
+        # switched off. The command is base64-carried now.
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(textwrap.dedent("""\
+                name: synthetic
+                jobs:
+                  lint:
+                    steps:
+                      - name: Continued command
+                        run: |
+                          test 1 -eq 1 \\
+                            -a 2 -eq 2
+                """), encoding="utf-8")
+            result = run(wf)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_local_ci.py
+++ b/scripts/tests/test_local_ci.py
@@ -20,7 +20,11 @@ SCRIPT = REPO_ROOT / "scripts" / "local-ci.sh"
 
 
 def run(workflow: Path | None, *args: str) -> subprocess.CompletedProcess:
-    env = dict(os.environ)
+    # The synthetic workflows below declare `lint` only. The script's default
+    # covers every gate job, and asking for an absent one is an error — see
+    # `test_an_unknown_job_answers_2`. Scoping here keeps these tests about
+    # derivation rather than about job coverage.
+    env = dict(os.environ, JOBS="lint")
     if workflow is not None:
         env["WORKFLOW"] = str(workflow)
     return subprocess.run(
@@ -45,7 +49,7 @@ class DerivationTests(unittest.TestCase):
     def test_a_gate_only_the_workflow_knows_about_is_listed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             wf = Path(tmp) / "ci.yml"
-            wf.write_text(workflow_with("Gate nobody hard-coded", "true"), encoding="utf-8")
+            wf.write_text(workflow_with("Gate nobody hard-coded", "'echo ok'"), encoding="utf-8")
             result = run(wf, "--list")
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("Gate nobody hard-coded", result.stdout)
@@ -57,7 +61,7 @@ class DerivationTests(unittest.TestCase):
             wf = Path(tmp) / "ci.yml"
             wf.write_text(workflow_with("Needs the runner", "echo $GITHUB_SHA"), encoding="utf-8")
             result = run(wf, "--list")
-            self.assertIn("SAUTÉE", result.stdout)
+            self.assertIn("SKIPPED", result.stdout)
             self.assertIn("Needs the runner", result.stdout)
 
 
@@ -67,7 +71,7 @@ class RefusalTests(unittest.TestCase):
     def test_a_failing_gate_makes_the_script_fail(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             wf = Path(tmp) / "ci.yml"
-            wf.write_text(workflow_with("Gate that fails", "false"), encoding="utf-8")
+            wf.write_text(workflow_with("Gate that fails", "'exit 1'"), encoding="utf-8")
             result = run(wf)
             self.assertEqual(result.returncode, 1)
             self.assertIn("Gate that fails", result.stderr)
@@ -82,7 +86,7 @@ class RefusalTests(unittest.TestCase):
     def test_an_unknown_job_answers_2(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             wf = Path(tmp) / "ci.yml"
-            wf.write_text(workflow_with("x", "true"), encoding="utf-8")
+            wf.write_text(workflow_with("x", "'echo ok'"), encoding="utf-8")
             env = dict(os.environ, WORKFLOW=str(wf), JOBS="does-not-exist")
             result = subprocess.run(
                 [str(SCRIPT), "--list"], capture_output=True, text=True,
@@ -106,16 +110,44 @@ class EmptyRunTests(unittest.TestCase):
             )
             result = run(wf)
             self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
-            self.assertIn("aucune étape", result.stderr)
+            self.assertIn("no steps read", result.stderr)
 
-    def test_a_boolean_run_value_does_not_silently_empty_the_run(self) -> None:
-        # `run: true` is parsed by YAML as a boolean, not the string "true".
+    def test_a_boolean_run_value_is_refused_rather_than_coerced(self) -> None:
+        # `run: true` is a boolean to YAML. Coercing it produced "True", which
+        # is not a command, so the gate reported a failure it had invented — a
+        # verdict about nothing. A non-string `run:` is a malformed workflow.
         with tempfile.TemporaryDirectory() as tmp:
             wf = Path(tmp) / "ci.yml"
             wf.write_text(workflow_with("Boolean run", "true"), encoding="utf-8")
             result = run(wf)
+            self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+            self.assertIn("non-string", result.stderr)
+
+
+class MissingToolTests(unittest.TestCase):
+    """A tool this machine lacks is not a gate that refused."""
+
+    def test_a_shell_style_missing_command_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(workflow_with("Needs a tool", "'definitely-not-installed-xyz'"), encoding="utf-8")
+            result = run(wf)
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-            self.assertIn("Portes rejouées: 1", result.stdout)
+            self.assertIn("TOOL MISSING", result.stdout)
+
+    def test_a_cargo_style_missing_subcommand_is_not_a_failure(self) -> None:
+        # `cargo machete` says "no such command" and exits 101, not 127. The
+        # first version knew only the shell's wording and reported a FAILING
+        # GATE on a clean tree.
+        with tempfile.TemporaryDirectory() as tmp:
+            wf = Path(tmp) / "ci.yml"
+            wf.write_text(
+                workflow_with("Cargo subcommand", "'echo \"error: no such command: machete\" >&2; exit 101'"),
+                encoding="utf-8",
+            )
+            result = run(wf)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("TOOL MISSING", result.stdout)
 
 
 class EscapingTests(unittest.TestCase):


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## The failure this closes

A PR in this batch went red on `Lint & Format` **after passing every local check** — because the local check was narrower than the one CI runs:

| | |
|---|---|
| what I ran | `cargo clippy -p velesdb-core --lib` |
| what CI runs | `cargo clippy --workspace --all-targets ...` |

The difference is not cosmetic: `--all-targets` compiles the **test** code, which is exactly where the finding was.

Measured while writing this: the `lint` job declares **32 gate steps**. Two were being run by hand.

## Derived, not copied

`scripts/local-ci.sh` runs the gates by reading `.github/workflows/ci.yml`. A copied list drifts, and the drift is **silent** — it shows up as a green local gate followed by a red CI, which is the exact failure above. This repository already paid for that lesson: #1699 found the attribution rule spelled twice, the two copies knowing different patterns.

A step the workstation cannot replay — anything touching the runner environment — is **announced, never dropped in silence**. A gate skipped without saying so is worth less than one that is absent, because the operator believes it ran. Two of the thirty-two are in that category, and the summary line says so.

## Two defects its own suite found before it shipped

**A false red.** Carrying the command through escape sequences turned a trailing line-continuation into a literal `\` + `n`; the shell received an argument `n` and clippy was reported as failing on a clean tree. **A gate that accuses wrongly is how a gate gets switched off.** The command is base64-carried now.

**A false green, which is worse.** An unexpected value crashed the reader, the loop processed zero steps, and the script printed *"all replayable gates pass"*. An operator would have believed the gates ran. **Zero steps is now an error, exit 2, not a success.**

Both are pinned by tests so they cannot return.

## Exit codes follow the convention the other guards use

`1` is a refusal, `2` is "cannot read". A tree this could not parse never wears the exit code of a refusal it never made — the same rule `check-deferred-removals.py` and `check-version-sync.py` already follow.

## Type of Change

- [x] 🔧 Chore / tooling (no production behaviour changes)

## How Has This Been Tested?

`python3 -m unittest scripts.tests.test_local_ci` → **8 tests, OK**. They pin the properties that matter, not the happy path:

| test | what it proves |
|---|---|
| `a_gate_only_the_workflow_knows_about_is_listed` | the list is **derived**; a gate added to the workflow appears without touching the script |
| `a_runner_only_step_is_reported_rather_than_omitted` | skips are announced |
| `a_failing_gate_makes_the_script_fail` | it refuses |
| `a_missing_workflow_answers_2_not_1` | cannot-read ≠ refusal |
| `an_unknown_job_answers_2` | same |
| **`a_workflow_with_no_replayable_steps_answers_2`** | **the false green** |
| `a_boolean_run_value_does_not_silently_empty_the_run` | its trigger |
| `a_line_continuation_survives_the_round_trip` | **the false red** |

Run against `develop`: **30 gates replayed, 0 failures, 2 reported as runner-only.**

The script is **not** invoked by CI — it replays that job, so running it inside would be circular. Its suite is wired instead, so it cannot rot unnoticed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
