### PR TITLE
fix(agent): reject reinforce() on an expired-but-unswept procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Registered in `scripts/guards.json` with a refusal vector whose accepted
   control is an npm double that exits 1 in both states.
 
+- **`ProceduralMemory::reinforce`/`reinforce_with_strategy` could resurrect an
+  expired-but-unswept procedure.** Every other write path on the struct
+  (`relate`, `set_ttl`, `update_metadata`'s analog on `SemanticMemory`) rejects
+  a TTL-expired id via `memory_helpers::ensure_live` before touching it, but
+  `reinforce_with_strategy` fetched the point with a raw `collection.get`
+  instead, so reinforcing an id whose TTL had elapsed but had not yet been
+  swept by `auto_expire` silently mutated confidence, usage and success/failure
+  counters on a point already invisible to `recall`, `list_all` and `relate`.
+  It now shares `ensure_live` with the rest of the struct and returns
+  `NotFound`, matching every sibling accessor.
+
 ## [6.0.0] - 2026-09-02
 
 ### Security

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -470,7 +470,8 @@ impl ProceduralMemory {
     ///
     /// # Errors
     ///
-    /// Returns an error when procedure retrieval or update fails.
+    /// Returns [`AgentMemoryError::NotFound`] when the id is unknown or expired.
+    /// Returns other errors when collection access or persistence fails.
     pub fn reinforce(&self, procedure_id: u64, success: bool) -> Result<(), AgentMemoryError> {
         self.reinforce_with_strategy(procedure_id, success, &*self.reinforcement_strategy)
     }
@@ -479,7 +480,8 @@ impl ProceduralMemory {
     ///
     /// # Errors
     ///
-    /// Returns an error when procedure retrieval or update fails.
+    /// Returns [`AgentMemoryError::NotFound`] when the id is unknown or expired.
+    /// Returns other errors when collection access or persistence fails.
     pub fn reinforce_with_strategy(
         &self,
         procedure_id: u64,
@@ -488,12 +490,13 @@ impl ProceduralMemory {
     ) -> Result<(), AgentMemoryError> {
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
 
-        let points = collection.get(&[procedure_id]);
-        let point = points
-            .into_iter()
-            .flatten()
-            .next()
-            .ok_or_else(|| AgentMemoryError::NotFound(format!("Procedure {procedure_id}")))?;
+        let point = memory_helpers::ensure_live(
+            &collection,
+            &self.collection_name,
+            &self.ttl,
+            MemoryKind::Procedural,
+            procedure_id,
+        )?;
 
         let state = Self::extract_procedure_state(&point)?;
         let now = std::time::SystemTime::now()

--- a/crates/velesdb-core/src/agent/procedural_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory_tests.rs
@@ -2,6 +2,7 @@
 
 #[cfg(test)]
 mod tests {
+    use super::super::error::AgentMemoryError;
     use super::super::procedural_memory::ProceduralMemory;
     use super::super::reinforcement::FixedRate;
     use super::super::ttl::{MemoryKind, MemoryTtl};
@@ -280,6 +281,30 @@ mod tests {
 
         let all = pm.list_all().unwrap();
         assert!(all.iter().any(|p| p.id == 8));
+    }
+
+    #[test]
+    fn test_reinforce_on_expired_procedure_returns_not_found() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        // Shared TTL so the entry can be marked expired without physically
+        // removing the point — the "expired but not yet swept" window that
+        // every other write path on this struct already rejects via
+        // `memory_helpers::ensure_live`.
+        let ttl = Arc::new(MemoryTtl::new());
+        let pm =
+            ProceduralMemory::new(db, 4, Arc::clone(&ttl)).expect("ProceduralMemory::new failed");
+
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        pm.learn(1, "about_to_expire", &steps(1), Some(&emb), 0.5)
+            .unwrap();
+        ttl.set_expiry(MemoryKind::Procedural, 1, 0);
+
+        let err = pm.reinforce(1, true).unwrap_err();
+        assert!(
+            matches!(err, AgentMemoryError::NotFound(_)),
+            "reinforcing an expired-but-unswept procedure must return NotFound, got {err:?}"
+        );
     }
 
     // ── Serialize / Deserialize ────────────────────────────────────────────────


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

`ProceduralMemory::reinforce_with_strategy` fetched the point with a raw
`collection.get(&[procedure_id])`, skipping the TTL-liveness check every
sibling write path on the struct already applies. `memory_helpers::ensure_live`
documents the invariant directly: "Expired-but-not-yet-swept entries are
invisible on every read surface; write surfaces ... must reject them the same
way." `relate`, `set_ttl`, `relations`/`incoming_relations`, `recall`, and
`SemanticMemory::update_metadata`'s analog all go through it — `reinforce` was
the one outlier.

The effect: a procedure whose TTL had elapsed but had not yet been swept by
`auto_expire` is already invisible to `recall`, `list_all` and `relate`, yet
`reinforce`/`reinforce_with_strategy` would still silently mutate its
confidence, usage count and success/failure counters, then re-persist it —
resurrecting a point every other accessor treats as gone.

Fixes # (no tracked issue — found during a routine code-quality pass)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests — added `test_reinforce_on_expired_procedure_returns_not_found`
  (marks a learned procedure expired via the shared `MemoryTtl` without
  physically removing it, then asserts `reinforce` returns `NotFound`).
  Ran `cargo test -p velesdb-core --features persistence agent:: -- --test-threads=1`
  — 219 passed, 0 failed, including all `reinforce`/TTL tests.
- [x] `cargo test --doc --package velesdb-core` — 50 passed, 0 failed.
- [x] `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Guard scripts: `check_prod_unwraps.py`, `check-todo-annotations.py`,
  `check-ai-attribution.py`, `check-version-sync.py`, `check-feature-claims.py`,
  `check-promise-contract.py`, `check-doc-freshness.py` (all 5 guards) — all pass.

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

Not run in this sandbox: the full single-threaded `velesdb-core` lib suite
(thousands of tests across unrelated subsystems — HNSW, ColumnStore, etc. —
none of which this change touches), the full workspace clippy sweep, and
wasm/node-specific gates.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`, both `# Errors` doc comments)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch path touched; single function in `agent/procedural_memory.rs`.

## Additional Notes

Behavior change is narrow and intended: an expired-but-unswept procedure now
returns `NotFound` from `reinforce`/`reinforce_with_strategy` instead of being
silently resurrected, bringing it in line with every sibling accessor. No test
asserted the old raw error message, so nothing else changes.