### PR TITLE
refactor(core): name the score epsilon, and stop the merge doc claiming an allocation it makes

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -272,8 +272,13 @@ impl Collection {
     /// duplicated between `apply_sparse_batch_upsert` (single-point path) and
     /// `apply_sparse_batch_bulk` (bulk path). Callers keep ownership of their
     /// input shape (`Vec<(u64, BTreeMap)>` vs `BTreeMap<String, Vec<(u64,
-    /// SparseVector)>>`) and build the iterator of triples themselves, which
-    /// keeps this helper allocation-free.
+    /// SparseVector)>>`) and build the iterator of triples themselves, so this
+    /// helper never copies a caller's collection.
+    ///
+    /// It is not allocation-free, and this doc said it was until the run
+    /// batching below arrived: `run` grows to the longest same-name run, and
+    /// holds borrows rather than clones. The claim was true when the helper
+    /// only forwarded one entry at a time; nothing re-checked it afterwards.
     ///
     /// Feature-gated on `persistence` — on targets without persistence the
     /// sparse WAL does not exist and the caller short-circuits.

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -10,6 +10,14 @@ use crate::point::SearchResult;
 use crate::velesql::{CompareOp, Condition, GraphMatchPredicate};
 use std::collections::HashSet;
 
+/// Tolerance for `=` / `!=` against a similarity-score threshold.
+///
+/// Scores are floating-point, so exact equality is never the intent. The value
+/// was written out four times, once per branch of the ascending/descending
+/// split; four copies of a threshold are four places to change it and three to
+/// forget.
+const SCORE_EQ_EPSILON: f32 = 0.001;
+
 /// Per-query evaluation cache shared across all result rows.
 ///
 /// Holds graph-predicate anchor sets and (#904) the `Filter` built for each
@@ -401,8 +409,8 @@ impl Collection {
                 CompareOp::Gte => score >= threshold,
                 CompareOp::Lt => score < threshold,
                 CompareOp::Lte => score <= threshold,
-                CompareOp::Eq => (score - threshold).abs() < 0.001,
-                CompareOp::NotEq => (score - threshold).abs() >= 0.001,
+                CompareOp::Eq => (score - threshold).abs() < SCORE_EQ_EPSILON,
+                CompareOp::NotEq => (score - threshold).abs() >= SCORE_EQ_EPSILON,
             }
         } else {
             match op {
@@ -410,8 +418,8 @@ impl Collection {
                 CompareOp::Gte => score <= threshold,
                 CompareOp::Lt => score > threshold,
                 CompareOp::Lte => score >= threshold,
-                CompareOp::Eq => (score - threshold).abs() < 0.001,
-                CompareOp::NotEq => (score - threshold).abs() >= 0.001,
+                CompareOp::Eq => (score - threshold).abs() < SCORE_EQ_EPSILON,
+                CompareOp::NotEq => (score - threshold).abs() >= SCORE_EQ_EPSILON,
             }
         }
     }

--- a/crates/velesdb-core/src/collection/streaming/delta_merge.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta_merge.rs
@@ -50,8 +50,15 @@ pub fn merge_with_delta(
 /// Merges HNSW search results (as [`crate::ScoredResult`]) with delta buffer
 /// results.
 ///
-/// Zero-allocation variant that avoids the `ScoredResult` → `(u64, f32)` →
-/// `ScoredResult` round-trip in the search pipeline.
+/// Takes and returns [`crate::ScoredResult`] so callers already on that shape
+/// need no conversion pass of their own around the merge.
+///
+/// It is NOT allocation-free, and the doc claimed it was: the body collects
+/// into a `Vec<(u64, f32)>` and collects back, which is the very round-trip the
+/// old wording said it avoided. Merging on tuples is deliberate — it shares
+/// [`DistanceMetric::sort_results`] and the truncate with [`merge_with_delta`],
+/// and duplicating both to drop two allocations is a trade nobody has measured.
+/// Measure before making that trade; do not restore the claim without it.
 #[must_use]
 pub fn merge_with_delta_scored(
     hnsw_results: Vec<crate::scored_result::ScoredResult>,


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Two places where the code and what it says about itself had come apart.

**1. `where_eval` — a threshold written out four times.** The score-comparison
tolerance `0.001` appeared once per branch of the ascending/descending split,
four literals with no name. Four copies of a threshold are four places to change
it and three to forget. Now `SCORE_EQ_EPSILON`, same value, same expressions.

**2. `merge_with_delta_scored` — a doc comment claiming the opposite of the
code.** It was documented as a "zero-allocation variant that avoids the
`ScoredResult` → `(u64, f32)` → `ScoredResult` round-trip". The body performs
exactly that round-trip:

```rust
let mut merged: Vec<(u64, f32)> = hnsw_results
    .into_iter()
    .filter(|sr| !delta_ids.contains(&sr.id))
    .map(Into::into)          // ScoredResult -> (u64, f32)
    .collect();               // allocation 1
...
merged
    .into_iter()
    .map(crate::scored_result::ScoredResult::from)   // and back
    .collect()                // allocation 2
```

**The doc is what changes here, not the code.** Merging on tuples is deliberate:
it shares `DistanceMetric::sort_results` and the truncate with
`merge_with_delta`, and duplicating both to drop two allocations is a trade
nobody has measured. The new wording says that explicitly, so the claim is not
restored without the measurement that would justify it.

This one sits on the unconditional search path, so a reader optimising from the
doc would have started from a false premise about where the allocations are.

**3. `append_sparse_wal_entries` — the same defect, found by looking for it.**
Documented as "keeps this helper allocation-free". It holds a `Vec` that grows to
the longest same-name run. The sentence was true when the helper forwarded one
entry at a time; the run batching (`#1797` shape) invalidated it and nothing
re-checked. Doc corrected, code unchanged — the buffer is the point of the
batching (one `open` and one fsync per run instead of per entry).

### The audit behind change 3

After finding change 2 by accident, all **16** allocation claims in
`crates/*/src` doc comments were checked against their function bodies rather
than assuming the first was an outlier:

| | |
|---|---|
| **2 false** | `merge_with_delta_scored`, `append_sparse_wal_entries` — both by the same mechanism: a later change invalidated an earlier claim, and nothing alarmed |
| **1 flagged, verified correct** | `prepare_query` scopes its claim to the non-cosine branch (`Cow::Borrowed`) and describes the cosine allocation and its thread-local amortisation accurately |
| **13 accurate** | mostly borrow-based (`Cow`, `&'a`, `Copy` fields) |

The 40 `lock-free` claims were listed but not audited here — they read as
`DashMap`/atomic-backed and are a separate surface.

**No gate is proposed.** The detection heuristic produced one false positive in
three flags; a gate at that precision is a gate that gets switched off. Two
findings in sixteen claims is worth a bounded audit, which this is, not a
standing check nobody trusts.

### Provenance

Both surfaced while auditing the stale `refactor/persistence-fsync-durability`
branch. Its fsync work has since reached `develop` by another route — the three
writers it targeted (`sparse/persistence.rs`, `pq_persistence.rs`, `rabitq.rs`)
all use `storage::atomic_write` today — so these two changes are what was left of
it. The branch is deleted with this PR.

## Type of Change

- [x] ♻️ Refactor / documentation correctness (non-breaking, no behaviour change)

## How Has This Been Tested?

- [x] `cargo clippy -p velesdb-core --lib --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `cargo test -p velesdb-core --features persistence --lib collection::` — **1493 passed, 0 failed**, 2 ignored.
- [x] `cargo fmt -p velesdb-core -- --check` — clean.

No test is added: the epsilon change is value-preserving by construction (same
constant, same expressions, verified by the 1493 tests), and the second change
touches only a doc comment. A test asserting a doc string's wording would pass
without establishing anything about the code.

**Test Configuration:** macOS, Rust 1.90 (workspace MSRV).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — no behaviour change. One named constant replacing four
identical literals, and one doc comment.
