### PR TITLE
ci(binary-size): stop the gate racing itself — 60 of its last 60 runs were cancelled

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -11,22 +11,27 @@ name: Binary Size Gate
 # absorb the Linux x86_64 build delta this CI runner produces. They catch a
 # real regression (a multi-MB dependency, a bundled asset), not exact bytes.
 
-# Called by ci.yml on pull requests (see the note in gate-contracts.yml). The
-# `pull_request` trigger is gone so the ceiling reports inside `CI Success`, the
-# only required check. The `push` filter below still applies on develop/main.
+# Called by ci.yml (see the note in gate-contracts.yml) on pull requests AND on
+# pushes to develop/main -- ci.yml's own `push:` filter is a strict superset of
+# the paths this gate cares about. The `pull_request` trigger is gone so the
+# ceiling reports inside `CI Success`, the only required check.
+#
+# The standalone `push:` trigger is gone too, and its removal is a fix rather
+# than a loosening. It fired on the same develop/main pushes as ci.yml, and
+# both instances landed in the concurrency group below -- which, unlike
+# propagation-guard.yml's, does not carry `github.workflow`, so the two
+# collided and one killed the other. It was ALWAYS the standalone that died:
+# 60 of the last 60 standalone runs are `cancelled`, and the gate has never
+# once completed in this form. A workflow whose entire history reads
+# `cancelled` tells a reader the gate is broken; keeping it would also leave a
+# race that could one day cancel the ci.yml instance instead, turning a clean
+# tree red on a required check.
+#
+# Coverage is unchanged, and that is checkable rather than asserted: every path
+# the old filter listed is matched by ci.yml's `push:` paths (`Cargo.toml`,
+# `Cargo.lock`, `crates/**`, `scripts/**`, `.github/workflows/**`).
 on:
   workflow_call:
-  push:
-    branches: [develop, main]
-    paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/velesdb-core/**"
-      - "crates/velesdb-server/**"
-      - "crates/velesdb-cli/**"
-      - "crates/velesdb-migrate/**"
-      - "scripts/check_binary_size.py"
-      - ".github/workflows/binary-size.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

`binary-size.yml` fired **twice** on every push to `develop`/`main`: once
standalone via its own `push:` trigger, once called by `ci.yml`. Both landed in
the same concurrency group:

```yaml
concurrency:
  group: binary-size-${{ github.ref }}   # no `github.workflow`
  cancel-in-progress: true
```

so one killed the other. It was always the standalone that died:

```
$ gh run list --workflow binary-size.yml --limit 60 --json conclusion \
    | jq 'group_by(.conclusion)|map("\(.[0].conclusion): \(length)")'
  ["cancelled: 60"]
```

**60 runs, 60 cancellations. The gate has never once completed in this form.**

### What is and is not broken

The ceiling check itself runs fine — through `ci.yml`, on pushes as well as PRs:

```
$ gh run view 34329050613 --json event,headBranch,headSha,conclusion
  event=push branche=develop sha=7e214f9c -> success
  Binary Size Gate / Release binaries within ceilings -> success
```

Two things *are* broken:

1. **The signal.** A workflow whose entire history reads `cancelled` tells any
   reader auditing "does this gate run?" that it does not. That is the same
   class of defect as a gate outside `CI Success`'s `needs`: a check you can
   watch fail while nothing is wrong, or watch pass while nothing ran.
2. **The race.** Which instance wins is not guaranteed. Sixty-for-sixty says the
   ordering is stable today; nothing enforces it. If the `ci.yml` instance lost
   once, `binary-size` would report `cancelled`, `CI Success` reads `!= success`,
   and a clean tree goes red on a required check.

### Why remove the trigger rather than widen the concurrency group

Widening it (adding `github.workflow`, as `propagation-guard.yml` already does)
would let both run — doubling an expensive release-binary build for **zero
added coverage**. Every path the standalone filter listed is already matched by
`ci.yml`'s `push:` paths, which is checkable, not asserted:

| standalone filter | matched by `ci.yml` push paths |
|---|---|
| `Cargo.toml`, `Cargo.lock` | listed verbatim |
| `crates/velesdb-{core,server,cli,migrate}/**` | `crates/**` |
| `scripts/check_binary_size.py` | `scripts/**` |
| `.github/workflows/binary-size.yml` | `.github/workflows/**` |

`workflow_dispatch` stays, for manual checks.

### Why the four sibling workflows keep theirs

`doc-contract.yml`, `gate-contracts.yml`, `promise-contract.yml` and
`propagation-guard.yml` are also called by `ci.yml` **and** keep a `push:`
trigger — deliberately. Theirs are *unfiltered*, so they catch pushes that
`ci.yml`'s path filter skips. `gate-contracts.yml` states the reason in its own
header: *"Deliberately not path-filtered. A filter is how a gate quietly stops
running."* `propagation-guard.yml` additionally carries `github.workflow` in its
concurrency group, which is exactly the collision this PR removes the other way.

`binary-size.yml` was the only one with both problems at once: a *filtered*
`push:` whose paths are a strict subset of `ci.yml`'s, and a concurrency group
that collides.

## Type of Change

- [x] 🐛 Bug fix (CI configuration; no product behaviour change)

## How Has This Been Tested?

- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **826 tests, OK**, including the trigger and gate-reachability suites in `test_ci_gate_reachability.py`.
- [x] Coverage equivalence checked by parsing both `on.push.paths` lists rather than by eye — no path in the removed filter is unmatched by `ci.yml`'s.
- [x] The `ci.yml` invocation proven to run on a `push` event, not only on `pull_request` (run `34329050613` above).

The proof that matters here is post-merge and stated plainly: after this lands,
`gh run list --workflow binary-size.yml` should show no new `cancelled` entries,
and the gate should keep reporting inside `CI Success` on develop pushes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — one workflow's trigger list. No `hnsw`, `storage`, `Drop`,
`unsafe` or SIMD path touched.
