### PR TITLE
fix(security): audit every tracked lockfile, and close the js-yaml advisory the gate could not see

### DIFF
--- a/.github/workflows/gate-contracts.yml
+++ b/.github/workflows/gate-contracts.yml
@@ -51,14 +51,27 @@ jobs:
     # --omit=dev is NOT used: the advisory above was dev-only, and the point
     # is to see it. Lockfile-only, so no install and no network beyond the
     # registry metadata.
+    #
+    # Every `package-lock.json` the repository tracks is listed, and
+    # `test_npm_audit_gate.NpmAuditMatrixCoverageTests` fails if one is
+    # missing. The list used to hold four of eight, and the gap was not
+    # theoretical: GHSA-2883-xcg3-v3hh (js-yaml, high) landed in
+    # `crates/velesdb-node` on 2026-09-09 and Dependabot found it, not this
+    # gate. A hand-kept list of paths is a list that silently stops matching
+    # the tree, so the list stays hand-kept -- readable in the matrix -- and a
+    # test holds it to the tree.
     strategy:
       fail-fast: false
       matrix:
         path:
-          - sdks/typescript
+          - .
+          - crates/velesdb-node
+          - crates/velesdb-wasm/e2e
           - demos/tauri-rag-app
-          - examples/react-wasm-search
+          - examples/ecommerce_recommendation
           - examples/node-express-rag
+          - examples/react-wasm-search
+          - sdks/typescript
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Registered in `scripts/guards.json` with a refusal vector whose accepted
   control is an npm double that exits 1 in both states.
 
+- **The npm advisory gate audited four of the eight tracked lockfiles**, and
+  the four it omitted were audited by nothing. `js-yaml` was published
+  vulnerable (GHSA-2883-xcg3-v3hh, high: `maxTotalMergeKeys` does not bound CPU
+  for empty merge sources) on 2026-09-09 and reached the default branch inside
+  `crates/velesdb-node`, found by Dependabot rather than by the gate. Bumped
+  4.3.1 → 4.3.2, lockfile-only, same major. The matrix now lists all eight
+  roots, and the missing half of the check exists: the suite proved every
+  matrix entry was a real directory but never that the matrix was complete, so
+  `test_every_tracked_lockfile_is_audited` compares it against `git ls-files`
+  — no hard-coded count, which would pass the day a ninth lockfile appears.
+  The other three previously unaudited roots audit clean.
+
 - **`ProceduralMemory::reinforce`/`reinforce_with_strategy` could resurrect an
   expired-but-unswept procedure.** Every other write path on the struct
   (`relate`, `set_ttl`, `update_metadata`'s analog on `SemanticMemory`) rejects

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1770,9 +1770,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/scripts/tests/test_npm_audit_gate.py
+++ b/scripts/tests/test_npm_audit_gate.py
@@ -115,6 +115,35 @@ def _run(npm: Path, root: Path, *extra: str) -> subprocess.CompletedProcess[str]
     )
 
 
+def _matrix_paths() -> "list[str]":
+    """The `path:` entries of the npm-audit matrix, in declaration order."""
+    job = _npm_audit_job()
+    marker = "\n        path:\n"
+    matrix = job[job.index(marker) + len(marker) :]
+    paths = []
+    for line in matrix.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            break
+        paths.append(stripped[2:].strip())
+    return paths
+
+
+def _tracked_lockfile_roots() -> "set[str]":
+    """Directories holding a git-TRACKED package-lock.json, matrix-style.
+
+    Tracked rather than on-disk: an untracked lockfile under `node_modules/`
+    or left by a local install is not something CI can audit, and sweeping the
+    working tree would make this test depend on whoever ran `npm install`
+    last. The repository root is spelled `.`, as the matrix spells it.
+    """
+    out = subprocess.run(
+        ["git", "ls-files", "package-lock.json", "*/package-lock.json", "**/package-lock.json"],
+        cwd=ROOT, capture_output=True, text=True, check=True,
+    ).stdout.split()
+    return {str(Path(p).parent) for p in out}
+
+
 class ClassifyTests(unittest.TestCase):
     def test_a_completed_report_yields_its_counts(self) -> None:
         counts = gate.classify(_report(high=2, low=1))
@@ -339,21 +368,36 @@ class WiringTests(unittest.TestCase):
         self.assertNotIn("run: npm audit", job)
 
     def test_every_audited_path_in_the_matrix_exists(self) -> None:
-        job = _npm_audit_job()
-        matrix = job[job.index("\n        path:\n") + len("\n        path:\n") :]
-        paths = []
-        for line in matrix.splitlines():
-            stripped = line.strip()
-            if not stripped.startswith("- "):
-                break
-            paths.append(stripped[2:].strip())
-        self.assertGreaterEqual(len(paths), 4)
+        paths = _matrix_paths()
+        self.assertTrue(paths, "the audit matrix is empty -- the gate audits nothing")
         for path in paths:
             with self.subTest(path=path):
                 self.assertTrue(
                     (ROOT / path / "package-lock.json").is_file(),
                     f"{path} is audited by the matrix but has no package-lock.json",
                 )
+
+    def test_every_tracked_lockfile_is_audited(self) -> None:
+        """The other direction, which is the one that was missing.
+
+        `test_every_audited_path_in_the_matrix_exists` proved each matrix entry
+        was real; nothing proved the matrix was complete. It held four of the
+        eight tracked lockfiles, and the four it omitted were audited by
+        nothing. That is not hypothetical: GHSA-2883-xcg3-v3hh (js-yaml, high)
+        was published against `crates/velesdb-node` on 2026-09-09 and reached
+        the default branch, found by Dependabot rather than by this gate.
+
+        A count is deliberately not asserted -- a hard-coded 8 would pass the
+        day someone adds a ninth lockfile and forgets the matrix. The set is
+        compared to what git tracks.
+        """
+        unaudited = sorted(_tracked_lockfile_roots() - set(_matrix_paths()))
+        self.assertEqual(
+            unaudited,
+            [],
+            "package-lock.json tracked but absent from the npm-audit matrix in "
+            f"gate-contracts.yml, so no job audits it: {unaudited}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

**GHSA-2883-xcg3-v3hh** (`js-yaml`, **high** — `maxTotalMergeKeys` does not
bound CPU use for empty merge sources) was published on **2026-09-09** and
reached the default branch inside `crates/velesdb-node`.

**Dependabot found it. The `npm advisories` gate did not** — because that
lockfile is not one of the four paths its matrix listed, out of **eight** the
repository tracks:

| tracked lockfile | audited before |
|---|---|
| `sdks/typescript` | ✅ |
| `demos/tauri-rag-app` | ✅ |
| `examples/react-wasm-search` | ✅ |
| `examples/node-express-rag` | ✅ |
| `crates/velesdb-node` | ❌ ← the advisory landed here |
| `crates/velesdb-wasm/e2e` | ❌ |
| `examples/ecommerce_recommendation` | ❌ |
| `.` (repository root) | ❌ |

The gate's own header says why it exists: *"Dependabot opens alerts but blocks
nothing, so a known-vulnerable lockfile could sit in the tree indefinitely."*
For half the tree, that is exactly what it did.

## The fix, in two parts

**1. The advisory.** `js-yaml` 4.3.1 → 4.3.2 in `crates/velesdb-node` —
lockfile-only, same major, no `--force`, so `package.json` constraints are
untouched. `npm audit --audit-level=high` there now reports **0
vulnerabilities**.

The other three previously unaudited roots were measured before widening the
matrix, so this PR does not turn the gate red on pre-existing findings: all
three audit clean.

**2. The half of the check that was missing.** This is the part worth reading.

`test_every_audited_path_in_the_matrix_exists` already asserted that every
matrix entry is a real directory holding a lockfile. Nothing asserted the
converse — that every lockfile is in the matrix. **A check that verifies its
result but never its premise cannot fail in the direction that matters**, and
that asymmetry is how four lockfiles came to be audited by nothing.

`test_every_tracked_lockfile_is_audited` compares the matrix against
`git ls-files`. It is proven RED against the old four-entry matrix:

```
AssertionError: package-lock.json tracked but absent from the npm-audit matrix
in gate-contracts.yml, so no job audits it:
  ['.', 'crates/velesdb-node', 'crates/velesdb-wasm/e2e',
   'examples/ecommerce_recommendation']
```

It names exactly the four omitted roots — it could not have passed by accident.

**No count is asserted.** An `assertEqual(len(paths), 8)` would pass the day
someone adds a ninth lockfile and forgets the matrix, which is the same defect
one level up. The old test's `assertGreaterEqual(len(paths), 4)` is gone for
that reason.

`git ls-files` rather than a filesystem sweep: an untracked lockfile under
`node_modules/`, or one left by a local `npm install`, is not something CI can
audit, and walking the working tree would make the test depend on whoever ran
an install last.

## Type of Change

- [x] 🔒 Security fix (non-breaking)
- [x] 🐛 Bug fix — a gate that covered half of what it appeared to cover

## How Has This Been Tested?

- [x] `npm audit --audit-level=high` in `crates/velesdb-node` — **found 0 vulnerabilities** (was 1 high).
- [x] `npm audit --audit-level=high` in the three other newly-added roots — clean, measured *before* adding them.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **838 tests, OK**.
- [x] The new test seen **RED** against the pre-change matrix and **GREEN** after, output quoted above.
- [x] `gate-contracts.yml` re-parsed with PyYAML after the edit; the matrix reads as the eight expected paths.

**Test Configuration:** macOS, node 24 / npm.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — one dev-dependency lockfile bump within the same major, one
workflow matrix, one test.
