### PR TITLE
fix(ci): lint the gpu-less build too, and fix the one defect that was hiding there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,25 @@ jobs:
             --exclude velesdb-python --exclude velesdb-node \
             -- -D warnings -D clippy::pedantic
 
+      # The same sweep with `gpu` OFF. The step above is the ONLY workspace
+      # clippy in CI and it always enables `gpu`, so a lint that fires only in
+      # the gpu-less build was linted by nothing -- `cargo hack
+      # --feature-powerset` runs `check`, not `clippy`, and only on
+      # velesdb-memory. One such lint was sitting on `develop`:
+      # `try_gpu_route`'s receiver is read only inside `#[cfg(feature =
+      # "gpu")]`, so `clippy::unused_self` fired for anyone building without
+      # it, on a tree CI called clean.
+      #
+      # Cost was measured before adding it rather than assumed: with that one
+      # lint fixed, this configuration reports zero findings across the
+      # workspace, so the step goes green on arrival instead of importing a
+      # backlog.
+      - name: Run Clippy (strict, no gpu)
+        run: |
+          cargo clippy --workspace --all-targets --features persistence,update-check \
+            --exclude velesdb-python --exclude velesdb-node \
+            -- -D warnings -D clippy::pedantic
+
       # velesdb-node is a cdylib: `--all-targets` would build a test harness that
       # links N-API symbols and fail (same reason velesdb-python is excluded
       # above). Lint just its library target, which links cleanly. The crate's

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -428,7 +428,14 @@ impl NativeHnswInner {
     ///
     /// `query.len()` is authoritative for the index dimension: a query of
     /// wrong length would fail distance evaluation anyway.
+    // Both allows have the same single reason: this body is entirely inside
+    // `#[cfg(feature = "gpu")]`, so with the feature off nothing in the
+    // signature is read -- neither the parameters nor the receiver. The
+    // receiver's allow was missing, which made
+    // `cargo clippy -p velesdb-core --lib --features persistence` fail on a
+    // clean tree: CI lints one feature set, and it always includes `gpu`.
     #[allow(unused_variables)] // Reason: parameters unused when `gpu` is off
+    #[allow(clippy::unused_self)] // Reason: receiver unused when `gpu` is off
     fn try_gpu_route(
         &self,
         query: &[f32],


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

On a clean `develop`, this fails:

```
$ cargo clippy -p velesdb-core --lib --features persistence -- -D warnings -D clippy::pedantic
error: unused `self` argument
   --> crates/velesdb-core/src/index/hnsw/native_inner.rs:433:9
```

`try_gpu_route` reads its receiver **only** inside `#[cfg(feature = "gpu")]`:

```rust
#[allow(unused_variables)] // Reason: parameters unused when `gpu` is off
fn try_gpu_route(&self, query: &[f32], k: usize, ef_search: usize) -> Option<Vec<(usize, f32)>> {
    #[cfg(feature = "gpu")]
    if let HnswBackend::Standard(hnsw) = &self.backend { ... }
    None
}
```

The line above already carries the allow for the *parameters*, with exactly this
reason. The receiver's was simply missing — the author's builds had `gpu` on, so
the lint never fired for them.

## Why CI could not notice — the part worth fixing

CI has **exactly one** workspace clippy invocation, and it always enables `gpu`:

```
ci.yml:307  cargo clippy --workspace --all-targets --features persistence,gpu,update-check
```

`cargo hack --feature-powerset` is not a backstop here: it runs `check`, not
`clippy`, and only on `velesdb-memory`. So lints were **verified under one
feature combination and asserted for all of them** — and a defect duly sat on
`develop` in the other one.

This PR adds the same sweep with `gpu` off. **Its cost was measured before it
was added, not assumed** — the same discipline the `npm advisories` matrix got:

```
$ cargo clippy --workspace --all-targets --features persistence,update-check \
    -- -D warnings -D clippy::pedantic
  # before this PR: 1 finding — `unused_self`, the one above
  # after:          0 findings
```

The step is green on arrival rather than importing a backlog.

## RED first

The proof is the measurement above, run on `develop` before any edit: that exact
command named exactly this lint. The new CI step is not a check that cannot
fail — it has been seen failing, on the tree it now guards.

As a bonus the gate-replay tool merged this morning (#2229) picks the new step
up on its own, which is what it exists for:

```
$ ./scripts/local-ci.sh --list | grep -i clippy
  · [lint] Run Clippy (strict)
  · [lint] Run Clippy (strict, no gpu)      ← derived, not hard-coded
  · [lint] Run Clippy (velesdb-node cdylib)
  ...
```

## Why an `#[allow]` and not a restructure

The repository's standing rule is that an `#[allow]` must not silence something
unknown. This one does not: the receiver is genuinely read when `gpu` is on, and
genuinely unread when it is off, which is a fact about the `cfg`, not a lint to
be dodged. The alternative — making `try_gpu_route` a free function over
`&self.backend` — would reshape a method and both its call sites to accommodate
a lint. The two allows now sit together under one comment stating the single
reason they share.

## Type of Change

- [x] 🐛 Bug fix (non-breaking) — a lint failing on a clean tree
- [x] 🔧 CI coverage — lints checked under one feature set, now two

## How Has This Been Tested?

- [x] `cargo clippy --workspace --all-targets --features persistence,update-check -- -D warnings -D clippy::pedantic` — **clean** (1 finding before).
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — still **clean**; the added allow does not disturb the gpu build.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **838 tests, OK**, including `test_ci_gate_reachability` which parses the modified `ci.yml`.
- [x] `scripts/local-ci.sh --list` derives the new step.

**Test Configuration:** macOS, Rust 1.90 (workspace MSRV).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — one `#[allow]` with a stated reason and one CI step. No
behaviour change: the attribute is inert at runtime, and the new step only
lints.
