### PR TITLE
docs(changelog): downgrading past the .vectors v2 change works — measured, and now pinned by a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alignment, so a payload starting at byte 16 could never be mapped as one.
   Moving it is what lets the file *be* the arena rather than be copied into one.
 
-  **Compatibility runs one way.** A current binary reads v1 and v2; a binary
-  from before this change rejects a v2 file with `Unsupported version: 2`.
-  Downgrading past this release therefore requires re-persisting the index —
-  a plain `git checkout` of an older build will not open a database written by
-  this one. `.vectors` had no version-compat mechanism at all before this, so
+  **Downgrading works, and that was measured rather than reasoned about.** An
+  earlier draft of this entry said a `git checkout` of an older build "will not
+  open a database written by this one". That was read off the v1 reader — which
+  does refuse a v2 header with `Unsupported version: 2` — without checking
+  whether anything reaches it. Nothing does: a `v6.0.0` binary opens a database
+  written by this release and answers `len = 64` with the correct nearest
+  neighbour. Setting the version byte to 99, truncating the file to its header,
+  and deleting it outright all behave identically, because `.vectors` is a
+  derived artifact and the collection is rebuilt from `vectors.dat` / the WAL
+  when it cannot be used. The reverse direction is equally clean: this build
+  reads a v1 file and leaves it v1 rather than silently rewriting it.
+  `a_corrupt_vectors_file_does_not_prevent_opening` pins that fallback so this
+  paragraph is not prose anybody has to trust. `.vectors` had no version-compat mechanism at all before this, so
   the v1 read path was written here rather than inherited.
 
 ### Added

--- a/crates/velesdb-core/tests/vectors_format_roundtrip.rs
+++ b/crates/velesdb-core/tests/vectors_format_roundtrip.rs
@@ -208,6 +208,68 @@ fn seed(dir: &TempDir, ids: std::ops::Range<u64>, mode: StorageMode) {
     collection.flush_full().expect("test: flush");
 }
 
+/// One way of making a `.vectors` unusable, with the label a failure reports.
+type Mutilation = (&'static str, fn(&Path));
+
+/// An unusable `.vectors` must not prevent a collection from opening.
+///
+/// This is the property the v2 release note rests on. The note first claimed
+/// the opposite -- that an older build "will not open a database written by
+/// this one" -- read off the v1 reader, which does refuse a v2 header with
+/// `Unsupported version: 2`, without checking that anything reaches it.
+/// Measured against a real `v6.0.0` build: it opens a v2 database and returns
+/// the correct nearest neighbour. `.vectors` is a derived artifact, and the
+/// collection is rebuilt from `vectors.dat` / the WAL when it cannot be used.
+///
+/// The three mutilations are the ones that experiment ran, and each fails a
+/// different way: an unknown version is rejected by the header check, a
+/// header-only file passes the version check and then runs out of payload, and
+/// an absent file never opens at all. A test that only deleted the file would
+/// leave both read failures unexercised.
+///
+/// The control is the untouched arm: it asserts the same count from the same
+/// seed, so a harness that answered 0 everywhere could not pass.
+#[test]
+fn a_corrupt_vectors_file_does_not_prevent_opening() {
+    let mutilate: [Mutilation; 4] = [
+        ("intact (control)", |_| {}),
+        ("unknown version", |p| {
+            let mut bytes = std::fs::read(p).expect("test: read");
+            bytes[0..4].copy_from_slice(&99u32.to_le_bytes());
+            std::fs::write(p, bytes).expect("test: write");
+        }),
+        ("header only", |p| {
+            let bytes = std::fs::read(p).expect("test: read");
+            std::fs::write(p, &bytes[..16]).expect("test: truncate");
+        }),
+        ("absent", |p| std::fs::remove_file(p).expect("test: remove")),
+    ];
+
+    for (label, damage) in mutilate {
+        let dir = TempDir::new().expect("test: tempdir");
+        seed(&dir, 0..ADOPTED, StorageMode::Full);
+        damage(&vectors_file(dir.path()));
+
+        let db = Database::open(dir.path()).unwrap_or_else(|e| panic!("{label}: open failed: {e}"));
+        let collection = db
+            .get_vector_collection("docs")
+            .unwrap_or_else(|| panic!("{label}: collection missing"));
+        assert_eq!(
+            collection.len(),
+            usize::try_from(ADOPTED).expect("test: count fits a usize"),
+            "{label}: an unusable .vectors must not cost the collection its points"
+        );
+        let hit = collection
+            .search(&make_vector(7), 1)
+            .unwrap_or_else(|e| panic!("{label}: search failed: {e}"));
+        assert_eq!(
+            hit.first().map(|r| r.point.id),
+            Some(7),
+            "{label}: the rebuilt index must still answer correctly"
+        );
+    }
+}
+
 /// Opening a collection must never write to its `.vectors`, on either side of
 /// the arena capacity floor.
 ///


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`docs/*` → targets `develop`. ✅

## Description

The `.vectors` v2 entry in the unreleased CHANGELOG claimed:

> Downgrading past this release therefore requires re-persisting the index — a
> plain `git checkout` of an older build will not open a database written by
> this one.

**That is false.** I wrote it, and I wrote it from the v1 reader — which *does*
refuse a v2 header with `Unsupported version: 2` (`graph_io.rs:408` at `v6.0.0`).
Nothing checked whether anything reaches that refusal.

It is also the claim the release-version decision rested on: a one-way on-disk
break would have argued for `7.0.0` rather than `6.1.0`.

## The measurement

Two worktrees, one at `v6.0.0` and one at `develop`, each with a small
`examples/` probe over the public API. A database written by `develop`
(`.vectors` header: `version=2 count=64 dim=8`, 6144 bytes), opened by the
`v6.0.0` build:

```
OUVERTURE_BASE: ok | COLLECTION: ok, len=64 | RECHERCHE: ok, top1=Some(7)
```

Mutilating the file changes nothing:

| `.vectors` | `v6.0.0` result |
|---|---|
| intact v2 | `len=64`, `top1=Some(7)` |
| version byte set to 99 | identical |
| truncated to its 16-byte header | identical |
| deleted outright | identical |

`.vectors` is a **derived artifact**; the collection is rebuilt from
`vectors.dat` / the WAL when it cannot be used.

**Controls, because four identical results are exactly what a probe that
measures nothing produces:**

| control | result |
|---|---|
| empty directory | `COLLECTION: ABSENTE` |
| everything but `config.json` + `native_meta.bin` deleted | `len=0`, `top1=None` |

So the probe reads the directory. And the reverse direction is clean too: this
build opens a v1 file written by `v6.0.0` (`version=1`, 2064 bytes) and **leaves
it v1** — no silent in-place migration.

## What changes here

The paragraph is replaced by what was measured, and — more usefully — by a test,
so the next reader does not have to trust prose:
`a_corrupt_vectors_file_does_not_prevent_opening` runs the same three
mutilations plus an intact control arm.

**Its own control positive was checked and then removed.** A temporary fifth arm
clobbering `native_meta.bin` failed with:

```
thread '…' panicked at …:257:32:
TEMOIN: meta detruit: collection missing
```

so the harness detects an open that does not happen. Without that, four arms
asserting `len == 64` would prove only that the number 64 appears somewhere.

## Consequence for the release

`6.1.0` (minor) is correct. This was the open question blocking that decision.

## Not fixed here

**An unusable `.vectors` is masked in complete silence** — version 99, a
truncated file and a missing file all produce a working collection and no
diagnostic whatsoever. A disk error on that file is therefore indistinguishable
from a healthy database that pays a full rebuild. That is a real defect and it
is filed separately rather than smuggled into a documentation correction.

## Type of Change

- [x] 📝 Documentation correction (a false claim about behaviour)
- [x] ✅ Test coverage (the claim becomes executable)

## How Has This Been Tested?

- [x] `cargo test -p velesdb-core --features persistence --test vectors_format_roundtrip` — **5 passed, 0 failed**.
- [x] The new test seen RED via a deliberate fifth arm, output quoted above, arm removed.
- [x] `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic` — clean (`type_complexity` on the mutilation array was factored into a `Mutilation` alias).
- [x] `cargo fmt -p velesdb-core -- --check` — clean.
- [x] The cross-version experiment itself, against a real `v6.0.0` build, transcript above.

**Test Configuration:** macOS, Rust 1.90 (workspace MSRV).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — one CHANGELOG paragraph and one integration test. No
production code is touched.
