### PR TITLE
fix(search): Perfect is exhaustive, its doc said otherwise, and no ef number can express it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`SearchMode::quality()`** — the lossless `SearchMode` → `SearchQuality`
+  conversion. `SearchMode::ef_search()` cannot express `Perfect`: it returns
+  `usize::MAX` as a bruteforce sentinel that nothing reads, and the only
+  conversion available turns that into `SearchQuality::Custom(usize::MAX)` —
+  an uncapped graph traversal that is neither exhaustive nor covered by
+  `limits.max_perfect_mode_vectors`. Wiring `[search]` (#2087) through
+  `ef_search()` would therefore have silently downgraded a config asking for
+  `perfect` *and* bypassed its guard rail. `quality()` is the conversion that
+  wiring must use.
+
+### Fixed
+
+- **`SearchQuality::Perfect` was documented as the opposite of what it does.**
+  Its rustdoc described a graph search at `ef_search = 4096` that "tunes the
+  HNSW graph's effort and is not exhaustive", with a ~0.9994 recall figure at
+  1M. It is exhaustive: `try_search_special_quality` routes the variant to
+  `search_brute_force` before `ef_search` is read, and a collection above
+  `limits.max_perfect_mode_vectors` (default 500 000) is refused with
+  `Error::GuardRail` rather than scanned — so the 1M figure describes a run
+  that cannot happen. The doc was written from `ef_search()` without checking
+  which arm runs. Corrected, and pinned by
+  `crates/velesdb-core/tests/perfect_mode_semantics.rs`, which sees the guard
+  rail refuse and sees `ef = 4096` accepted on the same collection.
+
 ### Changed
 
 - **`.vectors` now has a v2 format: the payload starts page-aligned at byte

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -76,13 +76,38 @@ pub enum SearchMode {
 
 impl SearchMode {
     /// Returns the `ef_search` value for this mode.
+    ///
+    /// **Lossy for [`Self::Perfect`], which is why wiring must not use it.**
+    /// `usize::MAX` was written as a bruteforce sentinel and nothing reads it as
+    /// one: the only conversion available, `ef_to_quality`, turns it into
+    /// `SearchQuality::Custom(usize::MAX)` — an uncapped graph traversal that is
+    /// neither exhaustive nor covered by `limits.max_perfect_mode_vectors`.
+    /// A config asking for `perfect` would get a silently downgraded mode and a
+    /// bypassed guard rail. Use [`Self::quality`] instead (#2238).
     #[must_use]
     pub fn ef_search(&self) -> usize {
         match self {
             Self::Fast => 96,
             Self::Balanced => 160,
             Self::Accurate => 512,
-            Self::Perfect => usize::MAX, // Signals bruteforce
+            Self::Perfect => usize::MAX,
+        }
+    }
+
+    /// Returns the [`SearchQuality`](crate::SearchQuality) this mode means.
+    ///
+    /// The lossless counterpart to [`Self::ef_search`]: every mode maps onto a
+    /// named quality, including `Perfect`, which no `ef_search` number can
+    /// express because the engine special-cases the variant rather than the
+    /// value. This is the conversion the `[search]` wiring of issue #2087 must
+    /// use.
+    #[must_use]
+    pub fn quality(&self) -> crate::SearchQuality {
+        match self {
+            Self::Fast => crate::SearchQuality::Fast,
+            Self::Balanced => crate::SearchQuality::Balanced,
+            Self::Accurate => crate::SearchQuality::Accurate,
+            Self::Perfect => crate::SearchQuality::Perfect,
         }
     }
 }

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -101,6 +101,11 @@ impl SearchMode {
     /// express because the engine special-cases the variant rather than the
     /// value. This is the conversion the `[search]` wiring of issue #2087 must
     /// use.
+    ///
+    /// Gated on `persistence`, like `SearchQuality`'s own export: without that
+    /// feature there is no HNSW index for a quality to describe. `SearchMode`
+    /// itself stays available, because a config file parses on every build.
+    #[cfg(feature = "persistence")]
     #[must_use]
     pub fn quality(&self) -> crate::SearchQuality {
         match self {

--- a/crates/velesdb-core/src/index/hnsw/params.rs
+++ b/crates/velesdb-core/src/index/hnsw/params.rs
@@ -367,17 +367,22 @@ pub enum SearchQuality {
     Balanced,
     /// Accurate search with `ef_search=512`. ~100% recall.
     Accurate,
-    /// Highest-recall mode: `ef_search=4096` base with a large candidate pool
-    /// and exact SIMD re-ranking. Reaches exactly 1.0 on the ≤100K contract
-    /// tests; on a real 1M corpus (SIFT1M) it measures ~0.9994 — re-ranking can
-    /// only reorder candidates the graph surfaced, so the rare true neighbour
-    /// outside the ef=8192 pool at 1M is not recovered. See docs/BENCHMARKS.md §11.
+    /// Exhaustive: every stored vector is scored, so recall is 1.0 by
+    /// construction. This variant leaves the graph — `try_search_special_quality`
+    /// routes it straight to `search_brute_force` before `ef_search` is ever
+    /// consulted, so [`Self::ef_search`]'s `4096.max(k * 100)` is not the number
+    /// this mode runs at. It is O(n / cores).
     ///
-    /// This tunes the **HNSW graph's effort** and is not exhaustive. For a hard
-    /// 100% guarantee use the separate `SearchMode::Perfect`
-    /// (`crate::config::SearchMode`), which switches the *engine* to a bruteforce
-    /// full scan (O(n)) rather than staying on the graph. Same name, different
-    /// axis: `SearchQuality` = graph effort, `SearchMode` = engine choice.
+    /// **Guarded, and the guard is the reason to read this.** A collection
+    /// larger than `limits.max_perfect_mode_vectors` (default 500 000) makes
+    /// the search fail with [`crate::error::Error::GuardRail`] rather than run
+    /// a linear scan over it. Verified in
+    /// `perfect_quality_is_refused_above_the_configured_cap`.
+    ///
+    /// This paragraph said the opposite until #2238 — "tunes the HNSW graph's
+    /// effort and is not exhaustive", with a ~0.9994 recall figure at 1M that
+    /// this path cannot produce and a corpus size the guard would refuse. It
+    /// was read off `ef_search()` without checking which arm runs.
     Perfect,
     /// Custom `ef_search` value.
     Custom(usize),

--- a/crates/velesdb-core/tests/perfect_mode_semantics.rs
+++ b/crates/velesdb-core/tests/perfect_mode_semantics.rs
@@ -1,0 +1,125 @@
+#![cfg(feature = "persistence")]
+#![allow(clippy::cast_precision_loss)] // ids into f32 coordinates, deliberately
+#![allow(clippy::cast_possible_truncation)] // usize ids into u64, on a 200-point fixture
+
+//! What `Perfect` means on each of the two axes, pinned.
+//!
+//! Both axes carry a variant named `Perfect` and, until #2238, both described
+//! it wrongly. `SearchQuality::Perfect` was documented as staying on the graph
+//! at `ef_search = 4096`; it leaves the graph entirely. `SearchMode::Perfect`
+//! maps to an `ef_search` of `usize::MAX` commented "Signals bruteforce", which
+//! nothing reads as a signal.
+//!
+//! Both errors were made the same way — reading `ef_search()` without checking
+//! which arm of `try_search_special_quality` runs — so the corrections are
+//! pinned by behaviour rather than restated in prose.
+
+use velesdb_core::{Database, DistanceMetric, Point, SearchMode, SearchQuality, VelesConfig};
+
+const DIM: usize = 8;
+const POINTS: usize = 200;
+const CAP: usize = 10;
+
+const _: () = assert!(
+    CAP < POINTS,
+    "the cap must sit below the collection size or the guard rail cannot fire"
+);
+
+fn collection_with_cap(dir: &tempfile::TempDir, cap: usize) -> velesdb_core::VectorCollection {
+    let mut config = VelesConfig::default();
+    config.limits.max_perfect_mode_vectors = cap;
+    let db = Database::open_with_config(dir.path(), config).expect("test: open");
+    db.create_vector_collection("docs", DIM, DistanceMetric::Euclidean)
+        .expect("test: create");
+    let collection = db.get_vector_collection("docs").expect("test: collection");
+    let points: Vec<Point> = (0..POINTS)
+        .map(|id| Point::new(id as u64, vec![id as f32; DIM], None))
+        .collect();
+    collection.upsert(points).expect("test: upsert");
+    collection
+}
+
+/// `SearchQuality::Perfect` is exhaustive, and the cap that says so refuses it.
+///
+/// The two other arms are the control: without them a collection that refused
+/// *every* search would satisfy the first assertion. `ef = 4096` is the
+/// specific control that matters, because it is the number the old doc claimed
+/// `Perfect` runs at — it is accepted, so the two are demonstrably not the same
+/// path.
+#[test]
+fn perfect_quality_is_refused_above_the_configured_cap() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let collection = collection_with_cap(&dir, CAP);
+    let query = vec![7.0_f32; DIM];
+
+    let refused = collection
+        .search_with_quality(&query, 5, SearchQuality::Perfect)
+        .expect_err("Perfect above the cap must be refused");
+    let message = refused.to_string();
+    assert!(
+        message.contains("max_perfect_mode_vectors"),
+        "the refusal must name the knob that caused it, got: {message}"
+    );
+
+    assert!(
+        collection
+            .search_with_quality(&query, 5, SearchQuality::Accurate)
+            .is_ok(),
+        "only Perfect is capped; Accurate must still run"
+    );
+    assert!(
+        collection.search_with_ef(&query, 5, 4096).is_ok(),
+        "ef = 4096 is not Perfect: it stays on the graph and is not capped"
+    );
+}
+
+/// Raising the cap above the collection size lets the same call through.
+///
+/// Without this, the test above could pass on a collection that simply cannot
+/// answer a Perfect search at all.
+#[test]
+fn perfect_quality_runs_once_the_cap_allows_it() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let collection = collection_with_cap(&dir, POINTS + 1);
+    let hits = collection
+        .search_with_quality(&[7.0_f32; DIM], 5, SearchQuality::Perfect)
+        .expect("test: Perfect under the cap must run");
+    assert_eq!(hits.len(), 5, "an exhaustive scan still returns k results");
+    assert_eq!(
+        hits.first().map(|r| r.point.id),
+        Some(7),
+        "and it returns the exact nearest neighbour"
+    );
+}
+
+/// `SearchMode::quality()` reaches the guarded variant; `ef_search()` cannot.
+///
+/// This is the conversion the `[search]` wiring (#2087) must use. Routed
+/// through `ef_search()` instead, `perfect` becomes `Custom(usize::MAX)` —
+/// accepted by a collection the cap should have protected, which is the silent
+/// downgrade this asserts against.
+#[test]
+fn search_mode_perfect_survives_only_the_lossless_conversion() {
+    assert_eq!(SearchMode::Perfect.quality(), SearchQuality::Perfect);
+    assert_eq!(SearchMode::Fast.quality(), SearchQuality::Fast);
+    assert_eq!(SearchMode::Balanced.quality(), SearchQuality::Balanced);
+    assert_eq!(SearchMode::Accurate.quality(), SearchQuality::Accurate);
+
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let collection = collection_with_cap(&dir, CAP);
+    let query = vec![7.0_f32; DIM];
+
+    assert!(
+        collection
+            .search_with_quality(&query, 5, SearchMode::Perfect.quality())
+            .is_err(),
+        "via quality(), the mode reaches Perfect and the cap refuses it"
+    );
+    assert!(
+        collection
+            .search_with_ef(&query, 5, SearchMode::Perfect.ef_search())
+            .is_ok(),
+        "via ef_search(), it does not: an uncapped traversal the guard never sees. \
+         This assertion documents the loss -- flip it only by removing the loss."
+    );
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Two enum variants are named `Perfect`, on two different axes, and **both were
described wrongly** — by the same method: reading `ef_search()` without checking
which arm of `try_search_special_quality` actually runs. I made that mistake
twice while investigating this, including once in the first version of #2238,
which is why the corrections below are pinned by behaviour rather than restated.

### 1. `SearchQuality::Perfect` is exhaustive; its rustdoc said it is not

The old text:

> `ef_search=4096` base with a large candidate pool and exact SIMD re-ranking […]
> on a real 1M corpus (SIFT1M) it measures ~0.9994 […] This tunes the **HNSW
> graph's effort** and is not exhaustive.

`index/hnsw/index/search.rs:379`:

```rust
if matches!(quality, SearchQuality::Perfect) {
    return self.search_brute_force(query, k).map(Some);
}
```

The variant leaves the graph before `ef_search` is ever consulted. And the 1M
figure describes a run that cannot happen: `enforce_perfect_mode_limit` refuses
any collection above `limits.max_perfect_mode_vectors`, default **500 000**.

Measured, cap set to 10 on a 200-point collection:

```
search_with_quality(Perfect)  -> Err(GuardRail("Perfect (brute-force) search rejected:
                                  collection has 200 vectors, exceeding
                                  max_perfect_mode_vectors cap of 10 …"))
search_with_quality(Accurate) -> Ok(5)
search_with_ef(.., 4096)      -> Ok(5)
```

The third line is the one that settles it: **4096 is the number the old doc
claimed `Perfect` runs at, and it is accepted on the very collection `Perfect`
is refused on.** They are demonstrably not the same path.

### 2. `SearchMode::Perfect` cannot express itself as an `ef` number

```rust
Self::Perfect => usize::MAX, // Signals bruteforce
```

Nothing reads that sentinel. The only conversion available —
`ef_to_quality` (`collection/search/vector_filter.rs:202`) — turns it into
`SearchQuality::Custom(usize::MAX)`, which is:

- **not exhaustive** — an uncapped graph traversal (`Ok(5)` in 0.05 s, measured), and
- **not guarded** — `enforce_perfect_mode_limit` matches only `Perfect`.

So wiring `[search]` (#2087) through `ef_search()`, the only route that exists
today, would have given a config asking for `perfect` a **silently downgraded
mode and a bypassed guard rail**. That is the reason this PR exists before the
wiring rather than after it.

`SearchMode::quality()` is added as the lossless conversion, and `ef_search()`
now documents what it cannot express.

## Behaviour is unchanged

No production code path changes. What changes is that three claims which were
prose are now executable.

## RED first

`tests/perfect_mode_semantics.rs` was checked against a deliberately broken
engine — `enforce_perfect_mode_limit` short-circuited to `Ok(())` and
`quality()` pointed at `Balanced`:

```
thread 'search_mode_perfect_survives_only_the_lossless_conversion' panicked …
thread 'perfect_quality_is_refused_above_the_configured_cap'      panicked …
test result: FAILED. 1 passed; 2 failed
```

Two of three fail; the third (`runs_once_the_cap_allows_it`) correctly still
passes, since a neutered guard lets everything through. Both witnesses were
removed.

Each test carries its own control, because a collection that refused *every*
search would satisfy a naive version of the first: `Accurate` and `ef = 4096`
must still succeed, and a raised cap must let `Perfect` through and return the
exact nearest neighbour.

## Type of Change

- [x] 🐛 Bug fix — documentation that inverted the behaviour it described
- [x] ✨ New feature (non-breaking) — `SearchMode::quality()`, additive

## How Has This Been Tested?

- [x] `cargo test -p velesdb-core --features persistence --test perfect_mode_semantics` — **3 passed, 0 failed**.
- [x] Seen RED against a broken engine, transcript above, witnesses removed.
- [x] `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `cargo doc -p velesdb-core --no-deps` — no intra-doc-link warnings on the rewritten blocks.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **838 tests, OK**.
- [x] `cargo fmt -p velesdb-core -- --check` — clean.

**Test Configuration:** macOS, Rust 1.90 (workspace MSRV).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`, two rustdoc blocks)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — one additive method, two rustdoc blocks, one new test file. No
existing code path is modified, so the search hot path is untouched.

Closes #2238.
