### PR TITLE
ci(gate): CI Success never reports a verdict no execution produced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2034,12 +2034,73 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     needs: [lint, test, security, semver-checks, hygiene, wasm-check, memory-feature-matrix, internal-bench-check, drop-tightening-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
-    if: (always()) && (github.event.action != 'edited' || github.event.changes.base != null)
+    # The ONE job that must not carry the title/body-edit guard, and #2232 is
+    # why. Guarded, it skipped on a body edit -- and branch protection accepts a
+    # `skipped` required check, so the PR read CLEAN with no gate having run on
+    # the head commit. Measured on #2231: `CI Success: skipping`,
+    # `mergeStateStatus: CLEAN`, mergeable.
+    #
+    # Unguarded and naive it would be worse: its needs skip on such a run, so
+    # the chain below would turn every description edit RED. Hence the mirror
+    # step -- on a no-op edit this job reports the verdict of the real run for
+    # the same commit, and reports nothing when there is none.
+    #
+    # The invariant, and the only one worth remembering: `CI Success` never
+    # reports a verdict no execution produced.
+    if: always()
+    permissions:
+      contents: read
+      # The mirror step reads sibling runs of this same workflow.
+      actions: read
     steps:
+      # A run triggered by a title or body edit skips all 27 gate jobs (each
+      # carries the guard this one dropped), so their results say nothing. Take
+      # the verdict from the run that did the work instead.
+      #
+      # If this `if` does not fire when expected, the chain below runs against
+      # skipped needs and fails: loud and closed, never green-on-nothing.
+      - name: Mirror the real verdict on a no-op edit
+        id: mirror
+        if: github.event.action == 'edited' && github.event.changes.base == null
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          WF: ${{ github.workflow }}
+          RUNID: ${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          deadline=$((SECONDS + 2400))
+          while :; do
+            runs=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+                     --jq '[.workflow_runs[] | select(.name == env.WF and (.id|tostring) != env.RUNID)]') || runs=""
+            if [ -z "$runs" ]; then
+              echo "::warning::could not list runs for $HEAD_SHA; retrying"
+            else
+              verdict=$(printf '%s' "$runs" | jq -r '[.[] | select(.status == "completed")] | sort_by(.updated_at) | last | .conclusion // ""')
+              active=$(printf '%s' "$runs" | jq -r '[.[] | select(.status != "completed")] | length')
+              if [ "$verdict" = "success" ]; then
+                echo "mirroring a completed successful run for $HEAD_SHA"
+                exit 0
+              fi
+              if [ "${active:-0}" -eq 0 ]; then
+                echo "::error::no successful CI run exists for $HEAD_SHA (last verdict: ${verdict:-none}). This run skipped every gate because it was triggered by a description edit, so it has nothing to report. Re-run CI on this commit."
+                exit 1
+              fi
+            fi
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::still waiting on the real CI run for $HEAD_SHA after 40 minutes; refusing to report a verdict this run did not establish"
+              exit 1
+            fi
+            sleep 30
+          done
+
       # sonarcloud is intentionally absent from the gate below: it is an
       # external service (skipped on forks / token-less runs) and must not
       # block merges. It stays in `needs` so its status is visible here.
+      #
+      # Skipped when the mirror above ran: that step is the verdict then.
       - name: Check results
+        if: steps.mirror.conclusion == 'skipped'
         run: |
           [[ "${{ needs.lint.result }}" == "success" ]] && \
           [[ "${{ needs.test.result }}" == "success" ]] && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A description edit could make a pull request mergeable with no gate having
+  run.** `ci.yml` subscribes to `pull_request.edited` because a retarget emits
+  nothing else, and every job guards against title/body edits so a routine
+  description change does not cost a full CI run. `ci-success` carried that
+  guard too — so a body edit produced a run where all 27 gates *and the
+  required check* skipped, and branch protection accepts a skipped required
+  check. Measured on #2231: `CI Success: skipping`, `mergeStateStatus: CLEAN`,
+  mergeable on a commit nothing had verified.
+
+  `ci-success` now runs on every event and branches: on such a run it reports
+  the verdict of the real run for the same commit, waiting for one in flight
+  and refusing when none exists, rather than asserting over `needs` results
+  that are all `skipped`. Both paths can refuse; neither can pass on nothing.
+  Pinned by `NoOpEditCannotProduceAGreenCheckTests`, whose five assertions were
+  each seen failing against a deliberately broken workflow.
+
 - **`GeoPoint` coordinates were validated on insert but not on update.**
   `update_by_pk`, `update_multi_by_pk` and `batch_update` could each write a
   latitude or longitude outside `[-90, 90]` / `[-180, 180]`, which then fed

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -123,9 +123,16 @@ def chain_failure_branch(text: str) -> str:
     # legitimately contain `||` — the retarget guard does. Scanning from the
     # shell block keeps this on the chain's own tail while still seeing a
     # branch neutered to something brace-less like `|| true`.
-    run_at = chain.find("run:")
+    # Anchored on the chain's own step. `ci-success` gained a second `run:`
+    # ahead of it (#2232's mirror), whose body legitimately contains `||` —
+    # taking the first `run:` in the job returned that instead, and this test
+    # then asserted `exit 1` against the wrong shell block.
+    step_at = chain.find("- name: Check results")
+    if step_at == -1:
+        raise AssertionError("the ci-success job has no `Check results` step")
+    run_at = chain.find("run:", step_at)
     if run_at == -1:
-        raise AssertionError("the ci-success job has no `run:` chain")
+        raise AssertionError("the ci-success `Check results` step has no `run:` chain")
     body = chain[run_at:]
     marker = body.find("||")
     if marker == -1:
@@ -1432,6 +1439,11 @@ JOB_ID_RE = re.compile(r"^  ([a-z][a-z0-9_-]*):$", re.MULTILINE)
 RETARGET_GUARD_EXEMPT = {
     "mcp-doc-contract": "runs the guard self-tests; must never be skippable",
     "pr-governance": "reads the title and body; skipping it on an edit is skipping its input",
+    "ci-success": (
+        "the required check itself: guarded, it reported `skipped` on a body edit and "
+        "branch protection accepted that as green (#2232). It runs always and mirrors "
+        "instead — see NoOpEditCannotProduceAGreenCheckTests"
+    ),
 }
 
 RETARGET_GUARD_RE = re.compile(
@@ -1517,14 +1529,165 @@ class RetargetRerunTests(unittest.TestCase):
                     "exemption, or the list is documenting a rule that no longer holds",
                 )
 
-    def test_ci_success_carries_the_guard_too(self) -> None:
-        block = self.ci[self.ci.index("\n  ci-success:") :]
-        self.assertRegex(
-            block.split("\n    steps:", 1)[0],
+    def test_ci_success_runs_on_a_no_op_edit_instead_of_skipping(self) -> None:
+        """The inversion of the rule this test used to assert, and why.
+
+        It used to require `ci-success` to carry the guard, reasoning that a
+        job asserting `result == 'success'` over needs that skip would turn
+        every description edit RED, and that skipping with them was safe
+        because "a skipped check-run is accepted by branch protection".
+
+        That acceptance is the hole. Measured on PR #2231: a body edit produced
+        a run where all 27 gates and `ci-success` skipped, the PR reported
+        `CI Success: skipping` and `mergeStateStatus: CLEAN`, and it was
+        mergeable with no gate having run on the head commit (#2232).
+
+        The premise stays true — an unguarded job asserting over skipped needs
+        would be red on every edit — so the job branches before the chain
+        rather than skipping. `NoOpEditCannotProduceAGreenCheckTests` pins that
+        branch; this test only pins that the job is reachable at all.
+        """
+        header = self.ci[self.ci.index("\n  ci-success:") :].split("\n    steps:", 1)[0]
+        self.assertNotRegex(
+            header,
             RETARGET_GUARD_RE,
-            "ci-success asserts `result == 'success'` for each of its needs, so leaving it "
-            "unguarded while its needs skip on a title edit turns every such edit RED. It "
-            "must skip with them — a skipped check-run is accepted by branch protection.",
+            "`ci-success` carries the title-edit guard again, so it skips on a body edit — "
+            "and branch protection reads a skipped required check as satisfied (#2232)",
+        )
+        self.assertRegex(
+            header,
+            r"(?m)^    if:\s*always\(\)\s*$",
+            "`ci-success` must run on every event; anything narrower reintroduces a state "
+            "where the required check is absent or skipped rather than earned",
+        )
+
+
+# ---------------------------------------------------------------------------
+# A no-op edit must not be able to produce a green required check
+# ---------------------------------------------------------------------------
+
+#: The condition identifying a run triggered by a title/body edit — the exact
+#: negation of `RETARGET_GUARD_RE`. Spelled once so the mirror step and the
+#: guard cannot drift into describing different sets of runs.
+NO_OP_EDIT_RE = re.compile(
+    r"github\.event\.action\s*==\s*'edited'\s*&&\s*github\.event\.changes\.base\s*==\s*null"
+)
+
+
+def ci_success_steps(text: str) -> "list[str]":
+    """The `- name:` step blocks of `ci-success`, in order."""
+    block = text[text.index("\n  ci-success:") :]
+    following = re.search(r"\n  (?=\S)", block[1:])
+    if following is not None:
+        block = block[: following.start() + 1]
+    steps = block.split("\n      - name:")
+    return [("- name:" + s) for s in steps[1:]]
+
+
+class NoOpEditCannotProduceAGreenCheckTests(unittest.TestCase):
+    """`CI Success` never reports a verdict no execution produced.
+
+    A run triggered by a description edit skips all 27 gate jobs, so their
+    `result`s say nothing. Before #2232 `ci-success` skipped with them and
+    branch protection accepted the skip: PR #2231 read `CI Success: skipping`,
+    `mergeStateStatus: CLEAN`, and was mergeable on a commit no gate had run
+    against.
+
+    It now runs always and takes one of two paths — mirror the real run's
+    verdict, or assert over needs that actually ran. Both can refuse; neither
+    can pass on nothing. These tests pin that shape.
+    """
+
+    def setUp(self) -> None:
+        self.ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.steps = ci_success_steps(self.ci)
+
+    def test_the_job_has_a_step_scoped_to_a_no_op_edit(self) -> None:
+        matching = [s for s in self.steps if NO_OP_EDIT_RE.search(s)]
+        self.assertEqual(
+            len(matching),
+            1,
+            "exactly one `ci-success` step may carry the no-op-edit condition; "
+            f"found {len(matching)}",
+        )
+
+    def test_the_mirror_never_judges_from_skipped_needs(self) -> None:
+        """Reading `needs.*.result` on a no-op run is reading nothing."""
+        mirror = next(s for s in self.steps if NO_OP_EDIT_RE.search(s))
+        self.assertNotIn(
+            "needs.",
+            mirror,
+            "the no-op step reads a `needs` result, but on the run it exists for "
+            "every one of them is `skipped`",
+        )
+
+    def test_the_mirror_can_refuse(self) -> None:
+        mirror = next(s for s in self.steps if NO_OP_EDIT_RE.search(s))
+        self.assertIn(
+            "exit 1",
+            mirror,
+            "the no-op step has no failing path, so it can only ever report success",
+        )
+
+    def test_exactly_one_step_produces_the_verdict(self) -> None:
+        """The chain must stand down when the mirror ran, and only then."""
+        chain = next(s for s in self.steps if "Check results" in s)
+        self.assertRegex(
+            chain,
+            r"if:\s*steps\.\w+\.conclusion\s*==\s*'skipped'",
+            "the `Check results` step must be conditioned on the mirror having "
+            "skipped; unconditional, it asserts over skipped needs and turns every "
+            "description edit red",
+        )
+
+    def test_the_two_conditions_are_exact_negations(self) -> None:
+        """One spelling drifting from the other reopens the hole silently."""
+        mirror = next(s for s in self.steps if NO_OP_EDIT_RE.search(s))
+        self.assertIsNotNone(RETARGET_GUARD_RE.search(self.ci), "the guard vanished from ci.yml")
+        self.assertNotRegex(
+            mirror,
+            RETARGET_GUARD_RE,
+            "the no-op step carries the guard's own predicate as well as its negation",
+        )
+
+
+class NoOpEditParserTests(unittest.TestCase):
+    """RED-then-GREEN on synthetic text, per this module's parser contract."""
+
+    SYNTHETIC = """\
+jobs:
+  ci-success:
+    name: CI Success
+    if: always()
+    steps:
+      - name: Mirror
+        if: github.event.action == 'edited' && github.event.changes.base == null
+        run: exit 1
+      - name: Check results
+        if: steps.mirror.conclusion == 'skipped'
+        run: echo ok
+  next-job:
+    name: Something else
+"""
+
+    def test_step_parser_stops_at_the_next_job(self) -> None:
+        steps = ci_success_steps(self.SYNTHETIC)
+        self.assertEqual(len(steps), 2)
+        self.assertIn("Mirror", steps[0])
+        self.assertNotIn("Something else", steps[1])
+
+    def test_the_no_op_condition_is_recognised(self) -> None:
+        self.assertRegex(ci_success_steps(self.SYNTHETIC)[0], NO_OP_EDIT_RE)
+
+    def test_a_missing_condition_is_detected(self) -> None:
+        without = self.SYNTHETIC.replace(
+            "if: github.event.action == 'edited' && github.event.changes.base == null",
+            "if: always()",
+        )
+        self.assertEqual(
+            [s for s in ci_success_steps(without) if NO_OP_EDIT_RE.search(s)],
+            [],
+            "the parser reports a condition the text does not carry",
         )
 
 
@@ -1617,19 +1780,29 @@ class NoOpRunCannotCancelRealCiTests(unittest.TestCase):
             "cancel another only when it is not itself a no-op.",
         )
 
-    def test_the_predicate_is_spelled_the_same_as_the_job_guard(self) -> None:
-        """Two spellings of \"this run is a no-op\" is how the two drift apart."""
+    def test_the_predicate_is_spelled_the_same_as_every_job_guard(self) -> None:
+        """Two spellings of \"this run is a no-op\" is how the two drift apart.
+
+        Compared against every guarded job rather than against `ci-success`,
+        which stopped carrying the guard in #2232. Generalising it is the
+        stronger test anyway: the old one would have missed a single job
+        spelling the predicate differently from all the others.
+        """
         guard_in_cancel = RETARGET_GUARD_RE.search(cancel_in_progress(self.ci))
-        self.assertIsNotNone(guard_in_cancel)
-        block = self.ci[self.ci.index("\n  ci-success:") :].split("\n    steps:", 1)[0]
-        guard_in_job = RETARGET_GUARD_RE.search(block)
-        self.assertIsNotNone(guard_in_job)
-        self.assertEqual(
-            guard_in_cancel.group(0),
-            guard_in_job.group(0),
-            "the concurrency predicate and the job guard must be character-identical, so "
-            "editing one and not the other cannot silently reopen the hole",
-        )
+        self.assertIsNotNone(guard_in_cancel, "`cancel-in-progress` lost the no-op predicate")
+        guarded, _unguarded = jobs_with_guard(self.ci)
+        self.assertGreater(len(guarded), 20, "job discovery looks broken, not the guard")
+        for job in sorted(guarded):
+            with self.subTest(job=job):
+                found = RETARGET_GUARD_RE.search(job_block(self.ci, job))
+                self.assertIsNotNone(found, f"`{job}` reads as guarded but the regex finds nothing")
+                self.assertEqual(
+                    guard_in_cancel.group(0),
+                    found.group(0),
+                    "the concurrency predicate and every job guard must be "
+                    "character-identical, so editing one and not the others cannot "
+                    "silently reopen the hole",
+                )
 
 
 class CancelInProgressParserTests(unittest.TestCase):


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

**Editing a pull request description made it mergeable with no gate having run
against the head commit.** Measured on #2231 earlier today:

```
$ gh pr checks 2231  →  CI Success: skipping
$ gh pr view 2231    →  mergeable=MERGEABLE  mergeStateStatus=CLEAN
```

`ci.yml` subscribes to `pull_request.edited` because a **retarget emits nothing
else** — dropping it would leave a retargeted PR with an *absent* required
check, which is #2118 and blocks a merge with no way out. Every job therefore
guards against title/body edits so a routine description change does not cost a
full CI run. `ci-success` carried that guard too, so on such a run it skipped
along with its 27 needs — and **branch protection reads a skipped required
check as satisfied.**

The guard added in #2125 addresses the *other* half — a no-op run must not
cancel the real one — and its test passes. It does not close this half, and its
own docstring names the gap it left:

> Branch protection accepts a `skipped` required check, so `CI Success` then
> reported green having run nothing.

## The change

`ci-success` runs on every event and branches:

| run | path |
|---|---|
| anything but a no-op edit | the existing `[[ … == "success" ]]` chain, unchanged |
| a title/body edit | read the API for a completed run of this workflow on the same head SHA; wait up to 40 min for one in flight; refuse when none exists or the last is not green |

Both paths can refuse. Neither can pass on nothing.

**The property survives my being wrong.** If that step's condition does not fire
when expected, the chain runs against skipped needs and fails — loud and closed,
never green-on-nothing. After this morning, where I twice reasoned about a
GitHub expression and twice had to correct myself, that is not a hypothetical
worth glossing over.

### Why not the two obvious alternatives

- **Drop `edited` from the trigger** → reopens #2118: absent required check after a retarget.
- **Drop the guard and leave the chain naive** → every description edit turns the PR RED, since its needs skip. A gate that cries wolf gets switched off.

## Tests

Four existing tests encoded the old design. They were **rewritten, not deleted**
— one into its inverse, with the original reasoning preserved in the docstring
so the next reader sees why it flipped. Two got stronger on the way:

- the failure-branch parser now anchors on the chain's own step rather than the
  first `run:` in the job (the mirror introduced a second one, and the test was
  silently asserting `exit 1` against the wrong shell block);
- the predicate-spelling test compares `cancel-in-progress` against **every**
  guarded job instead of `ci-success` alone — the old form would have missed one
  job spelling the no-op predicate differently from all the others.

`NoOpEditCannotProduceAGreenCheckTests` pins the new shape. **Each of its five
assertions was seen failing** against a deliberately mutated workflow:

| mutation | caught |
|---|---|
| mirror's condition removed | ✅ |
| mirror reads `needs.*.result` | ✅ |
| both of the mirror's `exit 1` neutered | ✅ |
| `Check results` left unconditioned | ✅ |
| retarget guard restored on `ci-success` | ✅ |

**One honest limit:** neutering only *one* of the mirror's two `exit 1` is **not**
caught. The test asserts a refusal path exists, not that every one survives.
Stated rather than papered over.

## How Has This Been Tested?

- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **846 tests, OK** (838 before; 8 added).
- [x] The five mutations above, each run against the suite, workflow restored after each.
- [x] `bash -n` on the step body extracted from the YAML — clean.
- [x] The four `jq` branches exercised on synthetic payloads: a completed success, a run still in flight, no completed run, an empty list. `env.WF` / `env.RUNID` filtering verified to exclude this run and other workflows.
- [x] `ci.yml` re-parsed with PyYAML after the edit.

**The test that matters cannot be run locally**, and it will be run on this PR
itself: editing this description triggers exactly the scenario, on the workflow
that fixes it. I will do that once the first run completes and report which
branch fired.

## Type of Change

- [x] 🐛 Bug fix (non-breaking) — a required check that could report a verdict nothing established

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

**This one is high-risk and says so.** It changes the single required check for
the whole repository: a broken `ci-success` blocks every merge. Mitigations —
the PR exercises the new job itself (a `pull_request` run uses the workflow from
the PR); the change is additive to the existing chain rather than a rewrite of
it; and reverting is one commit.

Closes #2232.


---

## Expérience en cours

Cette section a été ajoutée par une édition du corps de cette PR, à 54 checks
verts et `CI Success: pass` sur `a73795e9`, avec un seul run `CI` complété sur ce
SHA (`34395620004`, `pull_request`, `success`).

L'édition déclenche un run `pull_request.edited` dont les 27 portes se skippent.
Avant ce correctif, `CI Success` s'y serait skippé aussi et la PR serait restée
`CLEAN` sans qu'aucune porte n'ait tourné sur le commit. Le résultat observé est
reporté ci-dessous.
