### PR TITLE
feat(memory): the extractor sends the schema it already states (#1944)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1717,6 +1717,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The Ollama extractor constrains decoding with its own schema (#1944).**
+  Every `/api/generate` call now carries the extraction contract as Ollama's
+  `format`, so a schema-broken reply is structurally impossible rather than
+  merely discouraged by the prompt. Measured on the extraction campaign
+  (#1943), constrained decoding moved the 8 GB tier from no eligible model to
+  two, and took one model from zero valid replies to all of them. It repairs
+  **structure, not comprehension**: a constrained small model returns valid
+  JSON that is more often wrong about the passage. The published tier table in
+  [`docs/guides/MEMORY_EXTRACTOR_MODELS.md`](docs/guides/MEMORY_EXTRACTOR_MODELS.md)
+  is deliberately left as measured until a campaign is replayed against the
+  schema the crate now sends.
 - **HTTP inference features are named by role (#1766).** `embedder-http` and
   `extractor-http` are now the canonical build features. The former `ollama`
   and `extract` names remain compatibility aliases, so existing dependency

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -13,6 +13,12 @@
 //! (bring your own LLM by implementing [`Extractor`]) while a batteries-included
 //! `OllamaExtractor` backend lives behind the `extractor-http` feature.
 
+#[cfg(feature = "extractor-http")]
+#[path = "extract_wire.rs"]
+mod wire;
+#[cfg(feature = "extractor-http")]
+use wire::{extraction_schema, fact_list_schema, generate_body};
+
 /// One extracted, graph-ready fact: a self-contained sentence plus the salient
 /// topics it concerns. The topics become shared graph hubs, so two facts about
 /// the same topic are reachable from one another even with no textual overlap.
@@ -1095,11 +1101,11 @@ fn extraction_from_reply(reply: &str) -> Result<Extraction, ExtractError> {
 #[cfg(feature = "extractor-http")]
 impl Extractor for OllamaExtractor {
     fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
-        facts_from_reply(&self.generate(&build_prompt(text))?)
+        facts_from_reply(&self.generate(&build_prompt(text), &fact_list_schema())?)
     }
 
     fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
-        extraction_from_reply(&self.generate(&build_graph_prompt(text))?)
+        extraction_from_reply(&self.generate(&build_graph_prompt(text), &extraction_schema())?)
     }
 }
 
@@ -1187,21 +1193,9 @@ impl OllamaExtractor {
     /// Ollama may have closed, and `ureq` will not replay a POST with a body.
     /// The whole attempt — POST and body read — is inside the closure so a
     /// truncated response is replayed rather than surfacing as a parse error.
-    fn generate(&self, prompt: &str) -> Result<String, ExtractError> {
+    fn generate(&self, prompt: &str, schema: &serde_json::Value) -> Result<String, ExtractError> {
         let url = format!("{}/api/generate", self.base_url);
-        let body = serde_json::json!({
-            "model": self.model,
-            "prompt": prompt,
-            "stream": false,
-            "think": false,
-            // Extraction models are large — the one this crate documents as an
-            // example is 21.9 GB — so an unload between calls is the dominant
-            // cost, not the generation. Shares the embedder's knob so one
-            // setting governs every Ollama call the daemon makes.
-            "keep_alive": crate::embedder::keep_alive(),
-            "options": { "temperature": 0, "num_predict": MAX_GENERATION_TOKENS },
-        })
-        .to_string();
+        let body = generate_body(&self.model, prompt, schema).to_string();
         let attempt = || {
             let response = self
                 .agent

--- a/crates/velesdb-memory/src/extract_tests.rs
+++ b/crates/velesdb-memory/src/extract_tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+// `fact_item_schema` is internal to the wire module: only this test reads it,
+// so importing it into `extract` itself would be an unused import there.
+use super::wire::fact_item_schema;
 
 /// Regression: the graph reply is an OBJECT whose first `[` belongs to the
 /// nested `facts` field. Slicing with the array preference grabbed that
@@ -176,4 +179,54 @@ fn rejects_response_without_field() {
         parse_generate_response(r#"{"oops":true}"#),
         Err(ExtractError::Backend(_))
     ));
+}
+
+/// The graph call must carry the schema as Ollama's `format` (#1944).
+///
+/// Measured, not assumed: passing the extraction schema moved the 8 GB
+/// tier from no eligible model to two, and took one model from zero valid
+/// replies to all of them. Dropping this field would undo that silently —
+/// every stub-backed test would stay green, because no stub reads it.
+#[test]
+fn the_graph_call_constrains_decoding_with_the_extraction_schema() {
+    let body = generate_body("qwen3:14b", "passage", &extraction_schema());
+    assert_eq!(
+        body["format"],
+        extraction_schema(),
+        "the graph call must send the extraction schema verbatim"
+    );
+    assert_eq!(body["options"]["temperature"], 0, "greedy decoding kept");
+}
+
+/// The fact-only call carries the array shape its own prompt states — the
+/// two prompts return different top-level types, so one schema cannot
+/// serve both.
+#[test]
+fn the_fact_only_call_constrains_decoding_with_the_array_schema() {
+    let body = generate_body("qwen3:14b", "passage", &fact_list_schema());
+    assert_eq!(body["format"]["type"], "array");
+    assert_eq!(body["format"]["items"], fact_item_schema());
+}
+
+/// The schema and the parser are one contract stated twice. A reply that
+/// satisfies every `required` key must survive the reader — if the two
+/// drift, constrained decoding starts guaranteeing a shape nothing reads.
+#[test]
+fn every_required_key_of_the_schema_is_a_key_the_parser_reads() {
+    let schema = extraction_schema();
+    let required: Vec<&str> = schema["required"]
+        .as_array()
+        .expect("the extraction schema declares required keys")
+        .iter()
+        .map(|key| key.as_str().expect("required keys are strings"))
+        .collect();
+    assert_eq!(required, ["facts", "relations", "attributes"]);
+
+    let reply = r#"{"facts": [{"fact": "Kaltar is fifteen.", "entities": ["kaltar"]}],
+        "relations": [{"subject": "zephyrin", "predicate": "pere de", "object": "kaltar"}],
+        "attributes": [{"entity": "kaltar", "key": "age", "value": 15}]}"#;
+    let extraction = extraction_from_reply(reply).expect("a schema-shaped reply parses");
+    assert_eq!(extraction.facts.len(), 1, "facts survive the reader");
+    assert_eq!(extraction.relations.len(), 1);
+    assert_eq!(extraction.attributes[0].value, serde_json::json!(15));
 }

--- a/crates/velesdb-memory/src/extract_wire.rs
+++ b/crates/velesdb-memory/src/extract_wire.rs
@@ -1,0 +1,109 @@
+//! The wire contract of one extraction call: the request body sent to Ollama,
+//! and the JSON Schemas sent inside it.
+//!
+//! Split out of `extract.rs` when constraining decoding (#1944) pushed that
+//! file past its frozen budget. The seam is not arbitrary: everything here
+//! describes what LEAVES the process, while `extract.rs` keeps what comes back
+//! and how it is read.
+//!
+//! Each schema still sits beside nothing else, which is the point — it is one
+//! contract stated twice, once for the sampler and once for the reader, and
+//! `every_required_key_of_the_schema_is_a_key_the_parser_reads` is what keeps
+//! the two from drifting.
+
+use super::MAX_GENERATION_TOKENS;
+
+/// The body of one `/api/generate` call, built where a test can read it.
+///
+/// Split out of [`super::OllamaExtractor`]'s `generate` so the wire contract can be
+/// asserted without a live model: a `format` that silently stopped being sent
+/// would restore the exact defect this shape exists to close, and no
+/// stub-backed extraction test would notice.
+#[cfg(feature = "extractor-http")]
+pub(super) fn generate_body(
+    model: &str,
+    prompt: &str,
+    schema: &serde_json::Value,
+) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "prompt": prompt,
+        "stream": false,
+        "think": false,
+        // The same contract the prompt states, restated as a grammar the
+        // sampler cannot leave. Structure only: it makes replies parsable, it
+        // does not make them true, and the prompt stays the place that says
+        // what to extract.
+        "format": schema,
+        // Extraction models are large — the one this crate documents as an
+        // example is 21.9 GB — so an unload between calls is the dominant
+        // cost, not the generation. Shares the embedder's knob so one setting
+        // governs every Ollama call the daemon makes.
+        "keep_alive": crate::embedder::keep_alive(),
+        "options": { "temperature": 0, "num_predict": MAX_GENERATION_TOKENS },
+    })
+}
+
+/// One `{"fact": …, "entities": […]}` item, as a JSON Schema.
+///
+/// Kept beside [`super::RawFact`], which is what parses it back: the two are one
+/// contract stated twice, once for the sampler and once for the reader, and
+/// they must be changed together.
+#[cfg(feature = "extractor-http")]
+pub(super) fn fact_item_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "fact": { "type": "string" },
+            "entities": { "type": "array", "items": { "type": "string" } },
+        },
+        "required": ["fact", "entities"],
+    })
+}
+
+/// The JSON Schema for [`super::build_prompt`]'s reply: a bare array of facts.
+#[cfg(feature = "extractor-http")]
+pub(super) fn fact_list_schema() -> serde_json::Value {
+    serde_json::json!({ "type": "array", "items": fact_item_schema() })
+}
+
+/// The JSON Schema for [`super::build_graph_prompt`]'s reply, mirroring
+/// [`super::RawExtraction`].
+///
+/// `value` keeps the `number` arm the prompt insists on ("Emit numbers as JSON
+/// NUMBERS, never strings"): constraining it to `string` would silently undo
+/// what the prompt spends a line asking for.
+#[cfg(feature = "extractor-http")]
+pub(super) fn extraction_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "facts": { "type": "array", "items": fact_item_schema() },
+            "relations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "subject": { "type": "string" },
+                        "predicate": { "type": "string" },
+                        "object": { "type": "string" },
+                    },
+                    "required": ["subject", "predicate", "object"],
+                },
+            },
+            "attributes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "entity": { "type": "string" },
+                        "key": { "type": "string" },
+                        "value": { "type": ["string", "number", "boolean"] },
+                    },
+                    "required": ["entity", "key", "value"],
+                },
+            },
+        },
+        "required": ["facts", "relations", "attributes"],
+    })
+}

--- a/docs/guides/MEMORY_EXTRACTOR_MODELS.md
+++ b/docs/guides/MEMORY_EXTRACTOR_MODELS.md
@@ -71,9 +71,13 @@ Two things to keep straight before acting on it:
 - **It repairs structure, not comprehension.** A constrained small model returns
   valid JSON that is more often wrong about the passage. It stops losing
   enrichment silently; it does not become accurate.
-- **`velesdb-memory` does not send `format` today.** Those figures describe a
-  product change, not a setting you can switch on. Until it ships, the tiers
-  above are what you get.
+- **`velesdb-memory` now sends `format` on every extraction call.** The figures
+  above were measured as a declared variant *before* that shipped, and the
+  schema the crate sends is a **superset** of the measured one: it also
+  constrains `facts`, which the bench variant left free. So the direction is
+  established and the tier table is not yet re-earned — the 8 GB and 12 GB rows
+  stay as published until a campaign is replayed against the schema the product
+  actually sends. Treat them as a floor, not as the last word.
 
 ## Settings that are yours to state, not to inherit
 

--- a/scripts/file-budgets-baseline.txt
+++ b/scripts/file-budgets-baseline.txt
@@ -1,6 +1,6 @@
 crates/velesdb-core/src/simd_native/x86_avx512.rs	1469
 crates/velesdb-memory/src/context.rs	1097
-crates/velesdb-memory/src/extract.rs	1559
+crates/velesdb-memory/src/extract.rs	1553
 crates/velesdb-memory/src/schema.rs	1119
 crates/velesdb-python/src/agent_memory_service.rs	1097
 crates/velesdb-python/src/options.rs	1123


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → targets `develop`. ✅

## Description

The extraction prompt has always ended with a strict JSON contract, but
`/api/generate` never carried it as Ollama's **`format`** — so honouring it was
left to the model's goodwill.

The 2026-08-16 extraction campaign measured what that costs: passing the schema
moved the **8 GB tier from no eligible model at all to two**, and took one model
from **zero valid replies to all of them**.

Both prompts are covered, and they need different shapes — the fact-only prompt
returns a bare array, the graph prompt an object of three sections. Each schema
sits beside the type that parses it back, because they are **one contract stated
twice** and drift between them would guarantee a shape nothing reads.
`every_required_key_of_the_schema_is_a_key_the_parser_reads` is what holds them
together.

**It repairs structure, not comprehension.** A constrained small model returns
valid JSON that is more often *wrong about the passage*. The published tier table
in `MEMORY_EXTRACTOR_MODELS.md` is deliberately left **as measured** until a
campaign is replayed against the schema the crate now sends, and the guide says
so rather than implying the 8 GB row is now filled.

## Provenance

Recovered from the parked `feat/memory-extractor-constrained-decoding` branch.
#1944's own comment records why that branch is parked: the extractor bench is
blocked 3/5 on Metal, so #1956 (`MAX_GENERATION_TOKENS`) and #1957 (model
choice) cannot close. **This slice does not depend on that measurement**, which
is why it ships alone.

The cherry-pick conflicted: `develop` has since moved the inline test module to
a sibling file. Resolved in favour of `develop`'s structure, carrying over the
**three genuinely new tests** and not the fifteen already migrated.

## The seam split, and why it is not scope creep

The change pushed `extract.rs` from **1559 → 1638** lines. Its budget is frozen,
and `check-file-budgets.py` is explicit: *"no over-budget file may grow."*

Widening the baseline was available and is the wrong move — the guard's own doc
says `--write-baseline` "exists to create or deliberately widen the baseline
ONCE, by a person who means to". So the request body and the two schemas moved
to `extract_wire.rs` instead.

**The seam is real, not a line-count trick:** everything in the new module
describes what *leaves* the process, while `extract.rs` keeps what comes back and
how it is read.

`extract.rs` lands at **1553 — four lines under its old ceiling** — and the
baseline is tightened to match, because the guard also refuses a stale entry
above the true count (a future regrowth could hide under it).

## RED first

Removing the `format` field from the request body:

```
thread '…the_fact_only_call_constrains_decoding_with_the_array_schema' panicked
thread '…the_graph_call_constrains_decoding_with_the_extraction_schema' panicked
test result: FAILED. 33 passed; 2 failed
```

Two of the three new tests fail. The third asserts schema/parser agreement and
**correctly survives** — it does not depend on the field being sent. Field
restored, 35 passed.

## How Has This Been Tested?

- [x] `cargo test -p velesdb-memory --features extractor-http --lib extract` — **35 passed, 0 failed**.
- [x] Seen RED with the `format` field removed, transcript above.
- [x] `cargo clippy -p velesdb-memory --all-targets --features extractor-http -- -D warnings -D clippy::pedantic` — clean.
- [x] The **eight** `velesdb-memory` feature-isolation checks (`--no-default-features --features <f> --all-targets`) — all OK.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **838 tests, OK**, including the file-budget guard against the tightened baseline.
- [x] `cargo fmt -p velesdb-memory -- --check` — clean.

Four `rustdoc` link errors appear under `--features extractor-http`
(`crate::http`, `crate::tls`). **Measured on `develop` first: the same four are
already there.** Not introduced here, not fixed here.

## Type of Change

- [x] ✨ New feature (non-breaking) — the wire contract now carries the schema
- [x] ♻️ Refactor — one seam split, forced by the frozen budget

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`, `MEMORY_EXTRACTOR_MODELS.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path touched. The
behaviour change is confined to one HTTP request body, and it is additive: a
model that already honoured the prompt sees the same contract restated.

Refs #1944.
