### PR TITLE
feat(config): wire [search]'s default_mode and ef_search into an unqualified search (#2087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`[search]`'s `default_mode` and `ef_search` reach the engine (#2087).** The
+  section was parsed, validated and ignored; an unqualified `search()` now
+  resolves through `SearchConfig::resolved_quality()`, with `ef_search` winning
+  over `default_mode` as that field's doc has always promised. Resolution
+  belongs to `Database`, the only component holding a `VelesConfig`, and is
+  pushed to each collection on every open beside `[limits]` — never persisted.
+  Per-query overrides (`WITH (ef_search = N)`, `search_with_ef`,
+  `search_with_quality`) continue to win over it, and a default config leaves
+  `search()` on the built-in `Balanced` it already used.
+
+  `search.max_results` and `search.query_timeout_ms` stay inert and are now
+  warned about **field by field** rather than as a section, so the warning stops
+  naming knobs that work. Neither is an oversight: clamping a caller's `LIMIT`
+  silently is a footgun and erroring is a breaking change under a default
+  config, while a query timeout is a feature the engine does not have.
+
+  **`default_mode = "perfect"` is refused at config load**, with the reason.
+  `SearchQuality::Perfect` is an exhaustive scan capped by
+  `limits.max_perfect_mode_vectors`, and that cap lives in a check only the
+  per-query entry points can run — `search_with_optional_bitmap` returns
+  `Vec<ScoredResult>` and cannot refuse. Accepting it would have made one search
+  path scan a corpus of any size with the guard rail bypassed, which is the
+  shape #2238 removed from `SearchMode::ef_search`.
+
+  Hot-path cost measured against `develop` before merging, not after: six
+  alternating A/B passes, 84.4–88.0 µs vs 83.6–86.4 µs per `search()` on a
+  20 000-point fixture — overlapping ranges, no measurable regression. An
+  earlier draft closed over the index call and cost a reproducible +2.2 %; the
+  measurement is what caught it.
+
+### Added
+
 - **`SearchMode::quality()`** — the lossless `SearchMode` → `SearchQuality`
   conversion. `SearchMode::ef_search()` cannot express `Perfect`: it returns
   `usize::MAX` as a bruteforce sentinel that nothing reads, and the only

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -4,7 +4,6 @@ use super::resolve;
 use crate::collection::types::Collection;
 use crate::distance::DistanceMetric;
 use crate::error::{Error, Result};
-use crate::index::VectorIndex;
 use crate::point::SearchResult;
 use crate::quantization::{
     distance_pq_l2, pq_adc_batch_rescore, PQVector, ProductQuantizer, StorageMode,
@@ -38,7 +37,30 @@ pub(super) fn tag_vector_component_scores(results: &mut [SearchResult]) {
 }
 
 impl Collection {
-    fn search_ids_with_adc_if_pq(&self, query: &[f32], k: usize) -> Vec<ScoredResult> {
+    /// The index call the unqualified paths make, with the error handling the
+    /// `VectorIndex::search` impl used to do for them.
+    #[inline]
+    fn search_index(
+        &self,
+        query: &[f32],
+        k: usize,
+        quality: crate::SearchQuality,
+    ) -> Vec<ScoredResult> {
+        self.storage
+            .index
+            .search_with_quality(query, k, quality)
+            .unwrap_or_else(|e| {
+                tracing::error!("search_with_quality failed: {e}");
+                Vec::new()
+            })
+    }
+
+    fn search_ids_with_adc_if_pq(
+        &self,
+        query: &[f32],
+        k: usize,
+        quality: crate::SearchQuality,
+    ) -> Vec<ScoredResult> {
         let config = self.storage.config.read();
         let is_pq = matches!(config.storage_mode, StorageMode::ProductQuantization);
         let higher_is_better = config.metric.higher_is_better();
@@ -48,13 +70,18 @@ impl Collection {
         let oversampling = config.pq_rescore_oversampling.unwrap_or(0) as usize;
         drop(config);
 
+        // `search_with_quality` rather than `search`: the latter hard-codes
+        // `SearchQuality::Balanced`, which is exactly the built-in default this
+        // path now takes from the config instead. Its errors are swallowed the
+        // same way the `VectorIndex::search` impl swallows them, so behaviour is
+        // unchanged for a caller whose config is at its defaults.
         if !is_pq || oversampling == 0 {
-            let results = self.storage.index.search(query, k);
+            let results = self.search_index(query, k, quality);
             return self.merge_delta(results, query, k, metric);
         }
 
         let candidates_k = k.saturating_mul(oversampling).max(k + 32);
-        let index_results = self.storage.index.search(query, candidates_k);
+        let index_results = self.search_index(query, candidates_k, quality);
         let rescored =
             self.rescore_pq_candidates(query, k, metric, higher_is_better, index_results);
         self.merge_delta(rescored, query, k, metric)
@@ -327,7 +354,7 @@ impl Collection {
         crate::validation::validate_vector_is_finite(query)?;
 
         // Use HNSW index for fast ANN search
-        let index_results = self.search_ids_with_adc_if_pq(query, k);
+        let index_results = self.search_ids_with_adc_if_pq(query, k, self.runtime_search_quality());
 
         let vector_storage = self.storage.vector_storage.read();
         let payload_storage = self.storage.payload_storage.read();
@@ -519,7 +546,7 @@ impl Collection {
         let _metric = self.validate_query_and_read_metric(query)?;
 
         // Perf: Direct HNSW search without vector/payload retrieval
-        let results = self.search_ids_with_adc_if_pq(query, k);
+        let results = self.search_ids_with_adc_if_pq(query, k, self.runtime_search_quality());
         Ok(results)
     }
 
@@ -607,7 +634,12 @@ impl Collection {
         if let Some(opts) = opts {
             opts.record_executed_strategy(crate::velesql::FilterStrategy::PostFilter);
         }
-        self.search_ids_with_adc_if_pq(query, candidates_k)
+        // The configured default, not `opts.quality`: this fallback has never
+        // honoured a per-query quality -- the pre-filter branch above computes
+        // its own `ef` in the same way -- and this change does not start. With
+        // a default config it resolves to `Balanced`, exactly what the previous
+        // `index.search` hard-coded.
+        self.search_ids_with_adc_if_pq(query, candidates_k, self.runtime_search_quality())
     }
 }
 

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -541,6 +541,20 @@ pub(crate) struct RuntimeGuards {
     /// the setter can run after the registry has cloned the collection.
     /// **Not persisted** — re-pushed on every open.
     pub(crate) runtime_limits: Arc<RwLock<RuntimeLimits>>,
+
+    /// The [`SearchQuality`](crate::SearchQuality) an unqualified `search()`
+    /// uses, pushed from `VelesConfig::search` at registration time (#2087).
+    ///
+    /// Deliberately NOT a field of [`RuntimeLimits`]: a default is not a limit,
+    /// and that struct's contract is the three values `validate()` enforces.
+    /// Nothing reads both in one call either -- `search()` reads this,
+    /// `enforce_perfect_mode_limit` reads the other -- so the second lock costs
+    /// no acquisition on any path.
+    ///
+    /// Defaults to [`SearchQuality::Balanced`], which is what both index
+    /// implementations hard-code, so a direct `Collection::create`/`open`
+    /// caller sees no change. **Not persisted** -- re-pushed on every open.
+    pub(crate) runtime_search_quality: Arc<RwLock<crate::SearchQuality>>,
 }
 
 /// A collection of vectors with associated metadata.
@@ -601,6 +615,19 @@ impl Collection {
     /// Returns the current runtime limits snapshot (`Copy`, no lock retained).
     pub(crate) fn runtime_limits(&self) -> RuntimeLimits {
         *self.runtime.runtime_limits.read()
+    }
+
+    /// Overwrites the quality an unqualified `search()` resolves to (#2087).
+    ///
+    /// Same contract as [`Self::set_runtime_limits`]: pushed by the `Database`
+    /// registration paths from the live config, never persisted.
+    pub(crate) fn set_runtime_search_quality(&self, quality: crate::SearchQuality) {
+        *self.runtime.runtime_search_quality.write() = quality;
+    }
+
+    /// Returns the configured default quality (`Copy`, no lock retained).
+    pub(crate) fn runtime_search_quality(&self) -> crate::SearchQuality {
+        *self.runtime.runtime_search_quality.read()
     }
 
     /// Enforces the runtime ingest limits at the cold upsert boundary

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -119,14 +119,19 @@ impl SearchMode {
 
 /// Search configuration section.
 ///
-/// **Reserved — parsed and validated, not yet applied.** `[limits]` and
-/// `[hnsw]` reach the engine; this section does not.
-/// [`VelesConfig::validate`] warns when it deviates from its defaults so a
-/// config cannot silently promise behavior the engine does not deliver.
-/// Wiring is tracked in issue #2087 — `query_timeout_ms` in particular needs
-/// a query timeout the engine does not have, which is a feature of its own.
+/// **Half applied.** `default_mode` and `ef_search` reach the engine since
+/// #2087: an unqualified `search()` resolves through
+/// [`SearchConfig::resolved_quality`], with `ef_search` winning over
+/// `default_mode` when both are set.
+///
+/// `max_results` and `query_timeout_ms` are still inert and still warned about
+/// by [`VelesConfig::validate`], field by field. They are not oversights:
+/// clamping a caller's `LIMIT` silently is a footgun and erroring is a breaking
+/// change under a *default* config, while a query timeout is a feature the
+/// engine does not have. Both need a decision, not plumbing.
+///
 /// Per-query runtime overrides (`WITH (ef_search = N)`) are a separate,
-/// working mechanism.
+/// working mechanism and continue to win over anything here.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SearchConfig {
@@ -138,6 +143,26 @@ pub struct SearchConfig {
     pub max_results: usize,
     /// Query timeout in milliseconds.
     pub query_timeout_ms: u64,
+}
+
+impl SearchConfig {
+    /// The [`SearchQuality`](crate::SearchQuality) an unqualified `search()`
+    /// resolves to under this section.
+    ///
+    /// `ef_search` wins over `default_mode` when set, which is what the field's
+    /// own doc has always promised ("if set, overrides mode") and what nothing
+    /// used to honour, the section being inert.
+    ///
+    /// Goes through [`SearchMode::quality`] rather than
+    /// [`SearchMode::ef_search`] on purpose: the latter cannot express
+    /// `Perfect`, and routing through it would hand a `perfect` config an
+    /// uncapped traversal with `max_perfect_mode_vectors` bypassed (#2238).
+    #[cfg(feature = "persistence")]
+    #[must_use]
+    pub fn resolved_quality(&self) -> crate::SearchQuality {
+        self.ef_search
+            .map_or_else(|| self.default_mode.quality(), crate::SearchQuality::Custom)
+    }
 }
 
 impl Default for SearchConfig {

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -144,8 +144,15 @@ impl VelesConfig {
         }
 
         let mut inert: Vec<&'static str> = Vec::new();
-        if deviates(&self.search, &crate::config::SearchConfig::default()) {
-            inert.push("[search]");
+        // Field by field since #2087 wired `default_mode` and `ef_search`:
+        // reporting the whole section would fire on knobs that now work, which
+        // is how a warning trains its readers to ignore it.
+        let search_default = crate::config::SearchConfig::default();
+        if self.search.max_results != search_default.max_results {
+            inert.push("search.max_results");
+        }
+        if self.search.query_timeout_ms != search_default.query_timeout_ms {
+            inert.push("search.query_timeout_ms");
         }
         if self.hnsw.max_layers != crate::config::HnswConfig::default().max_layers {
             inert.push("hnsw.max_layers");
@@ -222,6 +229,28 @@ impl VelesConfig {
     }
 
     fn validate_search(&self) -> Result<(), ConfigError> {
+        // `perfect` as a GLOBAL default is refused, while
+        // `search_with_quality(Perfect)` per query stays available and guarded.
+        //
+        // The asymmetry is not squeamishness. `SearchQuality::Perfect` is an
+        // exhaustive scan capped by `limits.max_perfect_mode_vectors`, and that
+        // cap lives in `enforce_perfect_mode_limit`, which only the per-query
+        // entry points can call: `search_with_optional_bitmap` returns
+        // `Vec<ScoredResult>` with no way to refuse. Accepting the value here
+        // would make one of the three search paths scan a corpus of any size
+        // with the guard rail bypassed -- the exact shape #2238 removed from
+        // `SearchMode::ef_search`. Refusing beats degrading it in silence.
+        if matches!(self.search.default_mode, crate::config::SearchMode::Perfect) {
+            return Err(ConfigError::InvalidValue {
+                key: "search.default_mode".to_string(),
+                message: "`perfect` is an exhaustive scan and cannot be a global \
+                          default: one search path cannot enforce \
+                          `limits.max_perfect_mode_vectors`. Ask for it per query \
+                          instead, where the cap applies."
+                    .to_string(),
+            });
+        }
+
         if let Some(ef) = self.search.ef_search {
             if !(16..=4096).contains(&ef) {
                 return Err(ConfigError::InvalidValue {

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -64,6 +64,10 @@ impl Database {
         coll.set_runtime_limits(crate::collection::RuntimeLimits::from_config(
             &self.config.limits,
         ));
+        // `[search]` alongside `[limits]`, same contract: resolved here because
+        // `Database` is the only component holding a `VelesConfig`, pushed on
+        // every open, never persisted (#2087).
+        coll.set_runtime_search_quality(self.config.search.resolved_quality());
     }
 
     /// Checks whether a collection name exists in any of the typed registries.

--- a/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
+++ b/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
@@ -323,16 +323,39 @@ fn test_max_layers_reported_alongside_a_configured_wired_knob() {
     assert_eq!(config.inert_engine_entries(), vec!["hnsw.max_layers"]);
 }
 
+/// `[search]` is reported field by field now that two of its knobs work.
+///
+/// This test asserted the opposite until #2087 wired `default_mode` and
+/// `ef_search` — "[search] has no wired knob and stays reported as a whole
+/// section". That premise is what the wiring removed, and the reason the
+/// section-wide form had to go with it: a warning naming `[search]` while
+/// `default_mode` is applied would train its reader to ignore the whole line,
+/// which is the failure `test_max_layers_reported_alongside_a_configured_wired_knob`
+/// guards against one section over.
 #[test]
-fn test_search_reported_wholesale_storage_mode_reported_by_field() {
+fn test_search_and_storage_are_both_reported_by_field() {
     let mut config = VelesConfig::default();
     config.search.max_results = 42;
     config.storage.storage_mode = "memory".to_string();
     assert_eq!(
         config.inert_engine_entries(),
-        vec!["[search]", "storage.storage_mode"],
-        "[search] has no wired knob and stays reported as a whole section; \
-         storage_mode is the one [storage] field still awaiting a decision"
+        vec!["search.max_results", "storage.storage_mode"],
+        "only the knobs that still do nothing may be named"
+    );
+}
+
+/// Setting a WIRED `[search]` knob must report nothing at all.
+///
+/// The complement of the test above: without it, an `inert_engine_entries`
+/// that had simply stopped looking at `[search]` would satisfy both.
+#[test]
+fn test_a_configured_wired_search_knob_is_not_reported() {
+    let mut config = VelesConfig::default();
+    config.search.default_mode = crate::config::SearchMode::Accurate;
+    config.search.ef_search = Some(321);
+    assert!(
+        config.inert_engine_entries().is_empty(),
+        "default_mode and ef_search reach the engine; naming them would be a false warning"
     );
 }
 

--- a/crates/velesdb-core/tests/search_config_defaults.rs
+++ b/crates/velesdb-core/tests/search_config_defaults.rs
@@ -1,0 +1,152 @@
+#![cfg(feature = "persistence")]
+#![allow(clippy::cast_precision_loss)] // indices into f32 coordinates, deliberately
+
+//! `[search]` reaches an unqualified `search()` — asserted on results, not on a
+//! getter.
+//!
+//! The section was parsed, validated and ignored until #2087. Proving it is now
+//! applied means observing the SEARCH, because a test reading back the resolved
+//! quality would pass just as well if nothing consumed it.
+//!
+//! Every test here carries a control that makes its main assertion falsifiable:
+//! comparing two searches only means something once the fixture is shown to be
+//! hard enough that `ef_search` changes the answer at all.
+
+use velesdb_core::{Database, DistanceMetric, Point, SearchMode, VelesConfig};
+
+const DIM: usize = 32;
+const POINTS: usize = 3_000;
+const K: usize = 10;
+const LOW_EF: usize = 16; // the minimum `validate_search` accepts
+const HIGH_EF: usize = 4_096; // the maximum
+
+/// Deterministic pseudo-random coordinates: a fixture that changes between runs
+/// would make a recall-sensitive assertion flap.
+fn vector(seed: u64) -> Vec<f32> {
+    let mut x = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    (0..DIM)
+        .map(|_| {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            (x % 10_000) as f32 / 10_000.0
+        })
+        .collect()
+}
+
+fn seeded(dir: &tempfile::TempDir, config: VelesConfig) -> velesdb_core::VectorCollection {
+    let db = Database::open_with_config(dir.path(), config).expect("test: open");
+    db.create_vector_collection("docs", DIM, DistanceMetric::Euclidean)
+        .expect("test: create");
+    let collection = db.get_vector_collection("docs").expect("test: collection");
+    let points: Vec<Point> = (0..POINTS as u64)
+        .map(|id| Point::new(id, vector(id), None))
+        .collect();
+    collection.upsert(points).expect("test: upsert");
+    collection
+}
+
+fn ids(results: &[velesdb_core::SearchResult]) -> Vec<u64> {
+    results.iter().map(|r| r.point.id).collect()
+}
+
+fn config_with_ef(ef: usize) -> VelesConfig {
+    let mut config = VelesConfig::default();
+    config.search.ef_search = Some(ef);
+    config
+}
+
+/// `search.ef_search` reaches `search()`.
+///
+/// The control comes first: unless `LOW_EF` and `HIGH_EF` disagree on this
+/// fixture, comparing anything to the low-ef answer proves nothing. If that
+/// assertion ever fails the fixture got easy, and the message says so rather
+/// than leaving a green test that checks nothing.
+#[test]
+fn a_configured_ef_search_reaches_an_unqualified_search() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let collection = seeded(&dir, config_with_ef(LOW_EF));
+    let query = vector(POINTS as u64 + 1);
+
+    let low = ids(&collection
+        .search_with_ef(&query, K, LOW_EF)
+        .expect("test: low ef"));
+    let high = ids(&collection
+        .search_with_ef(&query, K, HIGH_EF)
+        .expect("test: high ef"));
+    assert_ne!(
+        low, high,
+        "CONTROL: ef must change the answer on this fixture, or the assertion below is vacuous"
+    );
+
+    assert_eq!(
+        ids(&collection.search(&query, K).expect("test: search")),
+        low,
+        "an unqualified search must use the configured ef, not the built-in Balanced"
+    );
+}
+
+/// A default config leaves `search()` exactly where it was.
+///
+/// The regression that matters most: every existing caller must see the
+/// built-in `Balanced` it saw before the wiring.
+#[test]
+fn a_default_config_leaves_search_on_the_built_in_quality() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let collection = seeded(&dir, VelesConfig::default());
+    let query = vector(POINTS as u64 + 1);
+    assert_eq!(
+        ids(&collection.search(&query, K).expect("test: search")),
+        ids(&collection
+            .search_with_quality(&query, K, velesdb_core::SearchQuality::Balanced)
+            .expect("test: balanced")),
+        "an unconfigured collection must answer exactly as Balanced does"
+    );
+}
+
+/// A per-query override still wins over the section.
+#[test]
+fn a_per_query_ef_still_overrides_the_configured_default() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let collection = seeded(&dir, config_with_ef(LOW_EF));
+    let query = vector(POINTS as u64 + 1);
+    assert_eq!(
+        ids(&collection
+            .search_with_ef(&query, K, HIGH_EF)
+            .expect("test: override")),
+        ids(&collection
+            .search_with_ef(&query, K, HIGH_EF)
+            .expect("test: override again")),
+        "CONTROL: the explicit path must be deterministic before it is compared"
+    );
+    assert_ne!(
+        ids(&collection
+            .search_with_ef(&query, K, HIGH_EF)
+            .expect("test: override")),
+        ids(&collection
+            .search(&query, K)
+            .expect("test: configured default")),
+        "the per-query ef must not be flattened onto the configured one"
+    );
+}
+
+/// `perfect` is refused as a global default, with the reason.
+#[test]
+fn perfect_is_refused_as_a_global_default() {
+    let mut config = VelesConfig::default();
+    config.search.default_mode = SearchMode::Perfect;
+    let message = config
+        .validate()
+        .expect_err("an exhaustive scan cannot be the default for every query")
+        .to_string();
+    assert!(
+        message.contains("max_perfect_mode_vectors"),
+        "the refusal must name the guard that cannot be enforced, got: {message}"
+    );
+
+    config.search.default_mode = SearchMode::Accurate;
+    assert!(
+        config.validate().is_ok(),
+        "CONTROL: only `perfect` is refused; the other modes must load"
+    );
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → targets `develop`. ✅

## Description

`[search]` was parsed, validated and **ignored**. An unqualified `search()` now
resolves its quality through `SearchConfig::resolved_quality()`, with
`ef_search` winning over `default_mode` — exactly what that field's doc has
always promised (*"if set, overrides mode"*) and what nothing honoured, the
section being inert.

This is the slice #2087's own design reserved for its own PR. Its prerequisite
shipped in #2239: `SearchMode::ef_search()` cannot express `Perfect`, so wiring
through it would have handed a `perfect` config an uncapped traversal with the
guard rail bypassed. `SearchMode::quality()` is the conversion used here.

## Three decisions worth reviewing

**1. A separate field, not a fourth member of `RuntimeLimits`.** A default is not
a limit, and that struct's contract is *"the three enforced fields"* `validate()`
polices. No path reads both in one call — `search()` reads the quality,
`enforce_perfect_mode_limit` reads the limits — so the second lock costs no
acquisition anywhere.

**2. The seam is `search_ids_with_adc_if_pq`, not a reroute to
`search_with_quality`.** Those are **two different pipelines**, and this is the
trap the investigation on #2087 was written to prevent:

| | `search()` | `search_with_quality()` |
|---|---|---|
| PQ oversampling | yes | **no** |
| delta-buffer merge | yes | **no** |

Sending the config default through the second would have changed far more than
the quality, silently.

**3. `default_mode = "perfect"` is refused at load, with the reason.**
`SearchQuality::Perfect` is an exhaustive scan capped by
`limits.max_perfect_mode_vectors`, and that cap lives in a check only the
per-query entry points can run: `search_with_optional_bitmap` returns
`Vec<ScoredResult>` and has no way to refuse. Accepting it would have let **one
of the three search paths scan a corpus of any size with the guard rail
bypassed** — the same shape #2238 removed from `SearchMode::ef_search`. Refusing
beats degrading it in silence, and the per-query `Perfect` stays available and
guarded.

## Hot path: measured before merging, not after

The design note on #2087 said the added lock read had to be measured first. It
was, and **the measurement earned its keep**: an earlier draft closed over the
index call and cost a reproducible **+2.2 %** — four alternating A/B passes with
disjoint ranges. An `#[inline]` method in the closure's place brings it back:

| | develop | this branch |
|---|---|---|
| 6 alternating passes | 84.4 – 88.0 µs | 83.6 – 86.4 µs |
| mean | 85.8 µs | 84.8 µs |

Overlapping ranges, faster on five of six pairs: no measurable regression.
20 000-point fixture, `--release`, best-of-5 inner runs, Apple M5 Pro.

## RED first

Removing the push from `Database` fails **two of the four** new tests. The other
two correctly survive — a default config is unchanged, and the `perfect` refusal
is validation-only.

**Every test carries its own control**, because comparing two searches proves
nothing until the fixture is shown to be hard enough that `ef` changes the
answer:

```rust
assert_ne!(low, high,
  "CONTROL: ef must change the answer on this fixture, or the assertion below is vacuous");
```

## One existing test rewritten, not deleted

`test_search_reported_wholesale_storage_mode_reported_by_field` asserted
*"[search] has no wired knob and stays reported as a whole section"*. That
premise is what this PR removes. Rewritten into its inverse with the original
reasoning preserved, and **given the complement it lacked**: setting a *wired*
knob must report **nothing**, or an `inert_engine_entries` that had simply
stopped looking at `[search]` would satisfy both tests.

## Still inert, on purpose

`search.max_results` and `search.query_timeout_ms`, now warned about **field by
field** so the warning stops naming knobs that work. Neither is an oversight:
clamping a caller's `LIMIT` silently is a footgun and erroring is a breaking
change under a *default* config, while a query timeout is a feature the engine
does not have. Both need a decision, not plumbing.

## How Has This Been Tested?

- [x] `cargo test -p velesdb-core --features persistence --test search_config_defaults` — **4 passed**, seen RED with the push removed.
- [x] `cargo test --lib collection::` — **1493 passed**; `--lib config` — **146 passed**.
- [x] `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `cargo check --workspace --no-default-features --exclude velesdb-python` — OK; `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` — OK. (Both replayed deliberately: the last public-API addition broke exactly these.)
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **846 tests, OK**.
- [x] The A/B latency measurement above.

## Type of Change

- [x] ✨ New feature (non-breaking) — a config section that was inert now applies
- [x] 🐛 Bug fix — `default_mode = "perfect"` would have bypassed a guard rail

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`, the `SearchConfig` section doc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

**Touches the default search path**, so it is treated as high-risk: the A/B
latency measurement above is part of the evidence, not an afterthought, and a
default config is asserted to leave `search()` byte-for-byte where it was. No
`hnsw`, `storage`, `Drop`, `unsafe` or SIMD dispatch path is modified.

Refs #2087.
