### PR TITLE
ci(gate): a refusal must say a new commit is needed, because re-running is not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2083,12 +2083,20 @@ jobs:
                 exit 0
               fi
               if [ "${active:-0}" -eq 0 ]; then
-                echo "::error::no successful CI run exists for $HEAD_SHA (last verdict: ${verdict:-none}). This run skipped every gate because it was triggered by a description edit, so it has nothing to report. Re-run CI on this commit."
+                # "Re-run CI" was this message's advice and it does not work.
+                # Branch protection evaluates EVERY check-run carrying the
+                # required name on a commit, not the most recent one, so the
+                # failure this step is about to record keeps the pull request
+                # BLOCKED even after a green re-run lands beside it. Measured on
+                # #2243: two `CI Success` check-runs on one SHA, 23:18 failure
+                # and 23:54 success, `mergeStateStatus: BLOCKED` with no red
+                # check visible to `gh pr checks`. A new commit is the way out.
+                echo "::error::no successful CI run exists for $HEAD_SHA (last verdict: ${verdict:-none}). This run skipped every gate because it was triggered by a description edit, so it has nothing to report. Push a new commit -- re-running is not enough, because this failed check-run stays on $HEAD_SHA and branch protection reads all of them."
                 exit 1
               fi
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::error::still waiting on the real CI run for $HEAD_SHA after 40 minutes; refusing to report a verdict this run did not establish"
+              echo "::error::still waiting on the real CI run for $HEAD_SHA after 40 minutes; refusing to report a verdict this run did not establish. Push a new commit: this failed check-run stays on the commit and branch protection reads all of them, so a re-run alone will not unblock it."
               exit 1
             fi
             sleep 30

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -1629,6 +1629,36 @@ class NoOpEditCannotProduceAGreenCheckTests(unittest.TestCase):
             "the no-op step has no failing path, so it can only ever report success",
         )
 
+    def test_every_refusal_says_a_new_commit_is_needed(self) -> None:
+        """Re-running is not enough, and the first version of these messages said it was.
+
+        Branch protection evaluates EVERY check-run carrying the required name
+        on a commit, not the most recent. So the failure this step records keeps
+        the pull request BLOCKED even once a green re-run lands beside it —
+        measured on #2243: two `CI Success` check-runs on one SHA, 23:18
+        failure and 23:54 success, `mergeStateStatus: BLOCKED` with no red check
+        visible to `gh pr checks`.
+
+        An error message that sends the reader down a path that cannot work
+        costs more than no message: they follow it, watch it fail, and stop
+        trusting the next one.
+        """
+        mirror = next(s for s in self.steps if NO_OP_EDIT_RE.search(s))
+        refusals = [line for line in mirror.splitlines() if "::error::" in line]
+        self.assertEqual(
+            len(refusals),
+            2,
+            f"expected the two refusal paths (no run, and timeout), found {len(refusals)}",
+        )
+        for line in refusals:
+            with self.subTest(refusal=line[:60]):
+                self.assertIn(
+                    "new commit",
+                    line,
+                    "a refusal must say that a new commit is required; re-running "
+                    "leaves the failed check-run on the same SHA",
+                )
+
     def test_exactly_one_step_produces_the_verdict(self) -> None:
         """The chain must stand down when the mirror ran, and only then."""
         chain = next(s for s in self.steps if "Check results" in s)


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

The refusal messages #2240 shipped a few hours ago end with **"Re-run CI on this
commit."** That advice does not work, and I followed it myself before noticing.

**Branch protection evaluates every check-run carrying the required name on a
commit, not the most recent one.** So the failure the mirror records stays on the
SHA and keeps the PR `BLOCKED` even once a green re-run lands beside it.

Measured on #2243, after I edited its description mid-CI and then re-ran:

```
$ gh api repos/…/commits/eb0c9508/check-runs   # name = "CI Success"
  23:18:30  failure   ← the no-op edit run
  23:54:22  success   ← the re-run

$ gh pr view 2243 --json mergeStateStatus
  BLOCKED

$ gh pr checks 2243     # …while this said:
  CI Success = pass
```

Two views of the same commit, and only one of them gates the merge. `gh pr
checks` shows the latest check-run per name; branch protection reads them all.
The PR was unblocked by amending to a fresh SHA, not by the re-run.

## The change

Both refusal paths — "no run exists" and "timed out waiting" — now say to push a
new commit and say **why** a re-run is not enough.
`test_every_refusal_says_a_new_commit_is_needed` holds them to it, and was seen
failing against a message restored to the old wording.

## Why this is worth its own PR

An error message that sends its reader down a path that cannot work costs more
than no message: they follow it, watch it fail, and trust the next one less.
This one had one working day to do that.

It is also a correction to a gate I shipped hours ago, in the same session. The
mechanism it fixes — *the tool's view of a commit is not the gate's view* — is
the same class as the defect #2240 itself addressed, one level further out.

## How Has This Been Tested?

- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **847 tests, OK**.
- [x] The new guard seen RED against the old wording, restored after.
- [x] `ci.yml` re-parsed with PyYAML; the `ci-success` job still declares its two steps in order.

## Type of Change

- [x] 🐛 Bug fix — an error message giving advice that cannot work

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no code.

## High-Risk Change Checklist

Touches the required check's job, so: the change is confined to two `echo
::error::` strings on paths that already exited non-zero. No condition, no exit
code and no step ordering is modified.

Refs #2232, #2240.
