### PR TITLE
test(persistence): a live guard for the .vectors fallback warning (#2237)

### DIFF
--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -742,3 +742,91 @@ fn test_runtime_limits_default_permissive_and_setter_overwrites() {
     assert_eq!(updated.max_payload_size, 64);
     assert_eq!(updated.max_perfect_mode_vectors, 5);
 }
+
+// ── Issue #2237: an unusable `.vectors` must warn, not stay silent ──────
+
+/// Reopening a collection whose `native_hnsw.vectors` cannot be read must
+/// emit a `warn` naming the fallback — not rebuild silently. A healthy
+/// reopen must NOT warn: without the control arm, a version of the guard
+/// that warned unconditionally would pass every damaged case and prove
+/// nothing.
+///
+/// `.vectors` staying a derived, rebuildable artifact is correct and must be
+/// kept (#2236, `a_corrupt_vectors_file_does_not_prevent_opening` in
+/// `tests/vectors_format_roundtrip.rs`); what was missing was the
+/// diagnostic. Without it, a disk error on this file is indistinguishable
+/// from a healthy reopen, and a future regression that corrupts `.vectors`
+/// on write would go unnoticed by every existing test. `try_load_hnsw`
+/// already carries the `tracing::warn!` this asserts on — this test is the
+/// live guard that keeps it firing (#1780/#2129-style: a comment or a code
+/// path is only as good as what checks it still holds).
+#[test]
+fn reopening_with_unusable_vectors_file_warns() {
+    use crate::point::Point;
+    use crate::test_fixtures::fixtures::capture_warns;
+
+    /// `(label, damage, expects the fallback warning)`.
+    type Mutilation = (&'static str, fn(&std::path::Path), bool);
+    let mutilations: [Mutilation; 4] = [
+        ("intact (control)", |_| {}, false),
+        (
+            "unknown version",
+            |p| {
+                let mut bytes = std::fs::read(p).expect("test: read .vectors");
+                bytes[0..4].copy_from_slice(&99u32.to_le_bytes());
+                std::fs::write(p, bytes).expect("test: write .vectors");
+            },
+            true,
+        ),
+        (
+            "header only",
+            |p| {
+                let bytes = std::fs::read(p).expect("test: read .vectors");
+                std::fs::write(p, &bytes[..16]).expect("test: truncate .vectors");
+            },
+            true,
+        ),
+        (
+            "absent",
+            |p| {
+                std::fs::remove_file(p).expect("test: remove .vectors");
+            },
+            true,
+        ),
+    ];
+
+    for (label, damage, expect_warning) in mutilations {
+        let temp_dir = tempfile::tempdir().expect("temp dir should be created");
+        let collection =
+            Collection::create(PathBuf::from(temp_dir.path()), 4, DistanceMetric::Cosine)
+                .expect("collection should be created");
+        collection
+            .upsert(vec![Point::without_payload(1, vec![1.0, 0.0, 0.0, 0.0])])
+            .expect("upsert should succeed");
+        collection.flush_full().expect("flush_full should succeed");
+        drop(collection);
+
+        let vectors_path = temp_dir.path().join("native_hnsw.vectors");
+        assert!(
+            vectors_path.exists(),
+            "{label}: precondition — native_hnsw.vectors must exist before damaging it"
+        );
+        damage(&vectors_path);
+
+        let (reopened, warns) = capture_warns(|| Collection::open(PathBuf::from(temp_dir.path())));
+        let reopened = reopened.unwrap_or_else(|e| panic!("{label}: open must still succeed: {e}"));
+
+        assert_eq!(
+            reopened.len(),
+            1,
+            "{label}: an unusable .vectors must not cost the collection its point"
+        );
+        let warned = warns
+            .iter()
+            .any(|w| w.contains("falling back to full rebuild from vector storage"));
+        assert_eq!(
+            warned, expect_warning,
+            "{label}: fallback-warning presence must match expectation, got: {warns:?}"
+        );
+    }
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`test/*` → targets `develop`. ✅

## Description

Closes #2237.

A `native_hnsw.vectors` that cannot be read (unknown version, truncated
header, or absent) must not reopen silently — the fallback to a full
rebuild from vector storage is correct (kept intentionally, see #2236),
but the issue is that nothing proved the diagnostic for it actually
fires.

Investigating, `try_load_hnsw` (`crates/velesdb-core/src/collection/core/lifecycle.rs`)
already carries the `tracing::warn!` the issue asks for, naming the
collection path and the underlying `io::Error` reason, for exactly this
fallback. What was missing was the second half of the issue's own ask:
*"un test qui voie l'avertissement, sinon on aura remplacé un silence
par un journal que rien ne vérifie"* — a live guard, so a future change
that silently breaks this warning fails a test instead of going
unnoticed (the omission-needs-a-live-guard principle in `AGENTS.md`).

This PR adds that guard as a test only — no production code changes.

## What changed

- `crates/velesdb-core/src/collection/core/lifecycle_tests.rs`: new test
  `reopening_with_unusable_vectors_file_warns`, reusing the
  `capture_warns` tracing-subscriber helper (already used by two other
  test files, previously unused for this path) to assert, for each of
  the three damage modes `tests/vectors_format_roundtrip.rs`'s
  `a_corrupt_vectors_file_does_not_prevent_opening` already exercises
  (unknown version, header-only truncation, file absent):
  - the collection still opens and keeps its point;
  - the fallback warning actually fires.

  Includes an intact control arm asserting the healthy path does NOT
  warn — without it, a guard that warned unconditionally would pass
  every damaged case and prove nothing.

## Type of Change

- [x] 📚 Documentation / test coverage (no functional change)

## How Has This Been Tested?

- [x] Unit tests
- New test run in isolation and as part of the full
  `collection::core::lifecycle_tests` module (26/26 passing).
- `cargo fmt --all -- --check`
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks`

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have made corresponding changes to the documentation (none needed — no behavior changed, only its test coverage)

## Additional Notes

No production code was touched. The warning this test guards already
existed in `try_load_hnsw`; the gap was purely in test coverage.