### PR TITLE
fix(hnsw): reorder_for_locality persists the graph it renumbered before returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   load call alone reports the cost as gone when it has only moved.
 
 ### Fixed
+
+- **`reorder_for_locality` could leave a collection whose graph and vectors
+  disagree.** Since `.vectors` became the graph's arena, the permutation lands
+  in the **durable** store the moment it runs, while the adjacency it must stay
+  consistent with is only written by a later `save()` — and
+  `Collection::reorder_for_locality` returned without persisting. Measured on a
+  3 000-point collection reopened (so adopted): `reorder_for_locality()` → `Ok`,
+  `.vectors` modified, `.graph` untouched. A crash, `SIGKILL`, OOM or power loss
+  in that window left every node id resolving to the wrong vector, silently,
+  because both files still parse — the failure `graph/reorder.rs` already
+  measures as "recall@10 1.000 before, 0.000 after". Reachable through
+  `POST /collections/{name}/locality/reorder`.
+
+  Before the arena adoption the permutation touched a disposable
+  `hnsw-{token}.arena` and no such window existed, so this is a regression that
+  arrived with the adoption rather than a latent defect. The index is now saved
+  before the call returns, and `reorder_durability.rs` pins it — seen failing
+  with the save removed.
 - **`SearchQuality::Perfect` was documented as the opposite of what it does.**
   Its rustdoc described a graph search at `ef_search = 4096` that "tunes the
   HNSW graph's effort and is not exhaustive", with a ~0.9994 recall figure at

--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -702,10 +702,27 @@ impl Collection {
     /// locality benefit; re-call after the next compaction if latency regresses.
     /// No-op for collections with fewer than 1 000 vectors.
     ///
+    /// # Durability
+    ///
+    /// The permutation is persisted before this returns, and that is not
+    /// optional. Since `.vectors` became the graph's arena, the permutation
+    /// lands in the **durable** store the moment it runs, while the adjacency
+    /// it must stay consistent with lives in `.graph`. Leaving the save to a
+    /// later `flush_full` opened a window in which a crash left every node id
+    /// resolving to the wrong vector -- silently, since both files parse.
+    /// Measured before the fix: `.vectors` modified, `.graph` untouched.
+    ///
+    /// Before the arena adoption the permutation touched a disposable
+    /// `hnsw-{token}.arena`, so no such window existed and no save was needed
+    /// here.
+    ///
     /// # Errors
     ///
-    /// Returns an error if vector storage reordering fails.
+    /// Returns an error if vector storage reordering fails, or if the
+    /// reordered index cannot be persisted.
     pub fn reorder_for_locality(&self) -> Result<()> {
-        self.storage.index.reorder_for_locality()
+        self.storage.index.reorder_for_locality()?;
+        self.storage.index.save(&self.storage.path)?;
+        Ok(())
     }
 }

--- a/crates/velesdb-core/tests/reorder_durability.rs
+++ b/crates/velesdb-core/tests/reorder_durability.rs
@@ -1,0 +1,166 @@
+#![cfg(feature = "persistence")]
+#![allow(clippy::cast_precision_loss)] // indices into f32 coordinates, deliberately
+
+//! `reorder_for_locality` must leave the two files it touches consistent.
+//!
+//! Since `.vectors` became the graph's arena, the permutation lands in the
+//! **durable** store the moment it runs, while the adjacency it must match
+//! lives in `.graph`. Leaving the save to a later `flush_full` opened a window
+//! where a crash left every node id resolving to the wrong vector — silently,
+//! because both files still parse. Measured before the fix:
+//!
+//! ```text
+//! reorder_for_locality()  ->  Ok
+//! .vectors  ->  modified without save
+//! .graph    ->  unchanged (old numbering)
+//! ```
+//!
+//! Before the arena adoption the permutation touched a disposable
+//! `hnsw-{token}.arena`, so no window existed. This file pins the invariant the
+//! adoption made necessary.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+use velesdb_core::{Database, DistanceMetric, Point};
+
+const DIM: usize = 16;
+/// Above `REORDER_THRESHOLD` (1 000), or the reorder is a documented no-op.
+const POINTS: u64 = 3_000;
+
+const _: () = assert!(
+    POINTS > 1_000,
+    "below the reorder threshold the permutation never runs and this file proves nothing"
+);
+
+/// Deterministic but dispersed.
+///
+/// The first draft used `(id * 31 + j) % 997`, which repeats past 997 ids: on a
+/// 3 000-point fixture two thirds of the vectors were duplicates and the
+/// nearest-neighbour control failed, returning 2231 for a query built from
+/// 1234. The control caught the fixture before the assertion it guards could
+/// pass on a coincidence.
+fn vector(id: u64) -> Vec<f32> {
+    let mut x = id.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    (0..DIM)
+        .map(|_| {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            (x % 10_000) as f32 / 10_000.0
+        })
+        .collect()
+}
+
+fn find(root: &Path, ext: &str) -> PathBuf {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("test: read_dir").flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == ext) {
+                return path;
+            }
+        }
+    }
+    panic!("test: no .{ext} under {}", root.display());
+}
+
+fn digest(path: &Path) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    std::fs::read(path).expect("test: read").hash(&mut hasher);
+    hasher.finish()
+}
+
+/// The permutation and the adjacency reach disk together.
+///
+/// Asserted on the FILES rather than through a reopen: a graceful drop flushes,
+/// which would repair the inconsistency before any assertion could see it. The
+/// window this guards is the one a crash falls into, and only the bytes on disk
+/// show it.
+#[test]
+fn reordering_persists_the_graph_it_renumbered() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    {
+        let db = Database::open(dir.path()).expect("test: open");
+        db.create_vector_collection("docs", DIM, DistanceMetric::Euclidean)
+            .expect("test: create");
+        let collection = db.get_vector_collection("docs").expect("test: collection");
+        collection
+            .upsert(
+                (0..POINTS)
+                    .map(|id| Point::new(id, vector(id), None))
+                    .collect::<Vec<_>>(),
+            )
+            .expect("test: upsert");
+        collection.flush_full().expect("test: flush");
+    }
+
+    let vectors = find(dir.path(), "vectors");
+    let graph = find(dir.path(), "graph");
+
+    let db = Database::open(dir.path()).expect("test: reopen");
+    let collection = db.get_vector_collection("docs").expect("test: collection");
+    let (vectors_before, graph_before) = (digest(&vectors), digest(&graph));
+
+    collection.reorder_for_locality().expect("test: reorder");
+
+    let (vectors_after, graph_after) = (digest(&vectors), digest(&graph));
+    assert_ne!(
+        vectors_before, vectors_after,
+        "CONTROL: the permutation must have reached the durable store, or this \
+         fixture never triggered a reorder and the assertion below is vacuous"
+    );
+    assert_ne!(
+        graph_before, graph_after,
+        "the durable vectors were permuted but `.graph` still carries the old \
+         numbering: a crash here resolves every node id to the wrong vector"
+    );
+}
+
+/// And the collection still answers correctly afterwards.
+///
+/// The complement: a `reorder` that corrupted the index while dutifully saving
+/// both files would satisfy the test above.
+#[test]
+fn a_reordered_collection_still_finds_its_nearest_neighbour() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let db = Database::open(dir.path()).expect("test: open");
+    db.create_vector_collection("docs", DIM, DistanceMetric::Euclidean)
+        .expect("test: create");
+    let collection = db.get_vector_collection("docs").expect("test: collection");
+    collection
+        .upsert(
+            (0..POINTS)
+                .map(|id| Point::new(id, vector(id), None))
+                .collect::<Vec<_>>(),
+        )
+        .expect("test: upsert");
+    collection.flush_full().expect("test: flush");
+
+    let probe = 1_234_u64;
+    let before = collection
+        .search(&vector(probe), 1)
+        .expect("test: search before")
+        .first()
+        .map(|r| r.point.id);
+    assert_eq!(
+        before,
+        Some(probe),
+        "CONTROL: the fixture must be findable at all"
+    );
+
+    collection.reorder_for_locality().expect("test: reorder");
+
+    assert_eq!(
+        collection
+            .search(&vector(probe), 1)
+            .expect("test: search after")
+            .first()
+            .map(|r| r.point.id),
+        Some(probe),
+        "the reorder renumbered the graph out from under the vectors"
+    );
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

**Lot P0 of #2246 — the most severe finding of the seven-lens review, and three
reviewers reached it independently.**

Since `.vectors` became the graph's arena, `reorder_for_locality` permutes the
**durable** store in place, while the adjacency it must stay consistent with lives
in `.graph` and was only written by a later `save()`.
`Collection::reorder_for_locality` (`collection/core/index_management.rs:708`)
delegated to the index and returned `Ok(())` **without persisting**.

Measured on a 3 000-point collection, reopened so adopted:

```
reorder_for_locality()  ->  Ok
.vectors  ->  MODIFIED without save
.graph    ->  unchanged (old numbering)
```

A crash, `SIGKILL`, OOM or power loss in that window leaves every node id
resolving to the **wrong vector, silently** — both files still parse. It is the
failure `graph/reorder.rs` already measures as *"recall@10 1.000 before, 0.000
after"*, and it was reachable through `POST /collections/{name}/locality/reorder`
(`velesdb-server/src/handlers/admin.rs:250`).

**A regression that arrived with the arena adoption, not a latent defect.** Before
it, the permutation touched a disposable `hnsw-{token}.arena` and no window
existed.

## The fix

The index is saved before the call returns. Refusing the reorder on an adopted
arena was the alternative, and the worse one: it would drop the optimisation on
exactly the collections large enough to benefit.

## Tests

`tests/reorder_durability.rs` asserts on the **files**, not through a reopen — a
graceful drop flushes and would repair the inconsistency before any assertion saw
it. The window this guards is the one a crash falls into, and only the bytes on
disk show it.

**RED first**, save removed:

```
panicked at reorder_durability.rs:112:
  the durable vectors were permuted but `.graph` still carries the old numbering:
  a crash here resolves every node id to the wrong vector
```

Each test carries a control. The first asserts the permutation reached the store
at all, or a fixture that never triggered a reorder would make the main check
vacuous. The second — that a reordered collection still finds its nearest
neighbour — **caught a bad first fixture**: `(id * 31 + j) % 997` repeats past
997 ids, and the check returned 2231 for a query built from 1234. Replaced before
the main assertion could pass on a coincidence.

## How Has This Been Tested?

- [x] `cargo test -p velesdb-core --features persistence --test reorder_durability` — **2 passed**, seen RED with the save removed.
- [x] `cargo test --lib collection::` — **1493 passed**; `--lib index::hnsw` — **560 passed**.
- [x] `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — **851 tests, OK**.

## Type of Change

- [x] 🐛 Bug fix — silent index corruption on crash after a reorder

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`, the method's rustdoc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

**Touches HNSW persistence**, treated as high-risk: the change is one added `save`
on a path that previously returned early, and the cost is paid only by an explicit
admin reorder, never by search or upsert.

Refs #2246.
