### PR TITLE
fix(config): a global perfect default is applied as accurate and warned about, not refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,19 +24,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently is a footgun and erroring is a breaking change under a default
   config, while a query timeout is a feature the engine does not have.
 
-  **`default_mode = "perfect"` is refused at config load**, with the reason.
-  `SearchQuality::Perfect` is an exhaustive scan capped by
+  **`default_mode = "perfect"` is applied as `accurate`, with a warning at
+  load.** `SearchQuality::Perfect` is an exhaustive scan capped by
   `limits.max_perfect_mode_vectors`, and that cap lives in a check only the
   per-query entry points can run — `search_with_optional_bitmap` returns
-  `Vec<ScoredResult>` and cannot refuse. Accepting it would have made one search
-  path scan a corpus of any size with the guard rail bypassed, which is the
-  shape #2238 removed from `SearchMode::ef_search`.
+  `Vec<ScoredResult>` and cannot refuse — so the global default never resolves
+  to it. A first version refused the value outright, which made a file v6.0.0
+  loaded fail `Database::open`: a breaking change in a minor release, caught by
+  the seven-lens review (#2246) before it shipped.
 
-  Hot-path cost measured against `develop` before merging, not after: six
-  alternating A/B passes, 84.4–88.0 µs vs 83.6–86.4 µs per `search()` on a
-  20 000-point fixture — overlapping ranges, no measurable regression. An
+  Hot-path cost measured against `develop` before merging, under a DEFAULT
+  config: six alternating A/B passes, 84.4–88.0 µs vs 83.6–86.4 µs per
+  `search()` on a 20 000-point fixture — overlapping ranges, no measurable
+  regression. That measures the plumbing and nothing else: under defaults the
+  resolved quality is `Balanced`, exactly what was hard-coded before, so the A/B
+  could not see the wiring's real effect and was not meant to (#2246). An
   earlier draft closed over the index call and cost a reproducible +2.2 %; the
   measurement is what caught it.
+
+  **Upgrade note.** A config that already set `default_mode` or `ef_search`
+  starts applying them — until now they were inert. `default_mode = "accurate"`,
+  which the "Production - High Precision" profile in `CONFIGURATION.md` ships,
+  moves an unqualified search from `160.max(k*5)` to `512.max(k*16)`
+  candidates.
 
 
 - **`SearchMode::quality()`** — the lossless `SearchMode` → `SearchQuality`

--- a/crates/tauri-plugin-velesdb/examples/production-config/velesdb.toml
+++ b/crates/tauri-plugin-velesdb/examples/production-config/velesdb.toml
@@ -24,7 +24,9 @@
 #   fast      ef_search 96,   ~95% recall
 #   balanced  ef_search 160,  ~99.5% recall — the default
 #   accurate  ef_search 512,  ~100% recall
-#   perfect   exhaustive brute force, 100% by construction, O(n)
+#   perfect   per query only: as a global default it is applied as
+#             accurate, with a warning at load -- an exhaustive scan
+#             cannot be capped on every search path
 default_mode = "balanced"
 
 # Hard cap on results per query. Allowed range: 1..=10000.

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -157,11 +157,25 @@ impl SearchConfig {
     /// [`SearchMode::ef_search`] on purpose: the latter cannot express
     /// `Perfect`, and routing through it would hand a `perfect` config an
     /// uncapped traversal with `max_perfect_mode_vectors` bypassed (#2238).
+    ///
+    /// `Perfect` itself is applied as `Accurate` here. A per-query `Perfect` is
+    /// capped by `enforce_perfect_mode_limit`; a global one would not be, since
+    /// one of the three search paths cannot refuse. `VelesConfig::validate`
+    /// warns when this downgrade happens rather than failing the load.
     #[cfg(feature = "persistence")]
     #[must_use]
     pub fn resolved_quality(&self) -> crate::SearchQuality {
-        self.ef_search
-            .map_or_else(|| self.default_mode.quality(), crate::SearchQuality::Custom)
+        self.ef_search.map_or_else(
+            || match self.default_mode {
+                // Applied as `Accurate`, and warned about at load by
+                // `validate()`: as a GLOBAL default an exhaustive scan would
+                // reach `search_with_optional_bitmap`, which cannot enforce
+                // `limits.max_perfect_mode_vectors`.
+                SearchMode::Perfect => crate::SearchQuality::Accurate,
+                mode => mode.quality(),
+            },
+            crate::SearchQuality::Custom,
+        )
     }
 }
 

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -87,14 +87,16 @@ impl VelesConfig {
         self.warn_inert_wal_batch();
         self.warn_deprecated_storage_fields();
         self.warn_inert_engine_sections();
+        self.warn_perfect_global_default();
         Ok(())
     }
 
-    /// The `[search]` section and `storage.storage_mode` are parsed and
-    /// validated but not yet applied (issue #2087). Warn — rather than
-    /// reject — when a config sets either away from its defaults, so
-    /// existing files keep loading while no deployment silently believes
-    /// those knobs work.
+    /// `storage.storage_mode` and `[search]`'s `max_results` /
+    /// `query_timeout_ms` are parsed and validated but not applied (issue
+    /// #2087); `[search]`'s `default_mode` and `ef_search` are applied since.
+    /// Warn — rather than reject — when a config sets an inert entry away from
+    /// its default, so existing files keep loading while no deployment
+    /// silently believes those knobs work.
     ///
     /// `[hnsw]` is no longer listed wholesale: `m` and `ef_construction` are
     /// applied at collection creation. Only `max_layers` remains inert — the
@@ -123,6 +125,28 @@ impl VelesConfig {
                  applied by the engine; see issue #2087. [limits] and \
                  [hnsw]'s m / ef_construction are applied. Query-time \
                  WITH (...) overrides are unaffected."
+            );
+        }
+    }
+
+    /// `search.default_mode = "perfect"` is accepted, applied as `accurate` by
+    /// `SearchConfig::resolved_quality`, and said so here.
+    ///
+    /// It was refused outright until the seven-lens review (#2246): a file
+    /// v6.0.0 loaded then failed `Database::open` -- a breaking change in a
+    /// minor release, against this module's own rule that existing files keep
+    /// loading. The reason for refusing still holds and is still honoured. As a
+    /// GLOBAL default `Perfect` would reach `search_with_optional_bitmap`, which
+    /// returns `Vec<ScoredResult>` and cannot enforce
+    /// `limits.max_perfect_mode_vectors`, so the default never resolves to it.
+    /// Per query, `search_with_quality(Perfect)` stays available and capped.
+    fn warn_perfect_global_default(&self) {
+        if matches!(self.search.default_mode, crate::config::SearchMode::Perfect) {
+            tracing::warn!(
+                "search.default_mode = \"perfect\" is applied as \"accurate\": an \
+                 exhaustive scan cannot be a global default, because one search \
+                 path cannot enforce limits.max_perfect_mode_vectors. Request \
+                 Perfect per query, where the cap applies."
             );
         }
     }
@@ -229,28 +253,6 @@ impl VelesConfig {
     }
 
     fn validate_search(&self) -> Result<(), ConfigError> {
-        // `perfect` as a GLOBAL default is refused, while
-        // `search_with_quality(Perfect)` per query stays available and guarded.
-        //
-        // The asymmetry is not squeamishness. `SearchQuality::Perfect` is an
-        // exhaustive scan capped by `limits.max_perfect_mode_vectors`, and that
-        // cap lives in `enforce_perfect_mode_limit`, which only the per-query
-        // entry points can call: `search_with_optional_bitmap` returns
-        // `Vec<ScoredResult>` with no way to refuse. Accepting the value here
-        // would make one of the three search paths scan a corpus of any size
-        // with the guard rail bypassed -- the exact shape #2238 removed from
-        // `SearchMode::ef_search`. Refusing beats degrading it in silence.
-        if matches!(self.search.default_mode, crate::config::SearchMode::Perfect) {
-            return Err(ConfigError::InvalidValue {
-                key: "search.default_mode".to_string(),
-                message: "`perfect` is an exhaustive scan and cannot be a global \
-                          default: one search path cannot enforce \
-                          `limits.max_perfect_mode_vectors`. Ask for it per query \
-                          instead, where the cap applies."
-                    .to_string(),
-            });
-        }
-
         if let Some(ef) = self.search.ef_search {
             if !(16..=4096).contains(&ef) {
                 return Err(ConfigError::InvalidValue {

--- a/crates/velesdb-core/tests/search_config_defaults.rs
+++ b/crates/velesdb-core/tests/search_config_defaults.rs
@@ -104,49 +104,93 @@ fn a_default_config_leaves_search_on_the_built_in_quality() {
     );
 }
 
-/// A per-query override still wins over the section.
+fn reopened(
+    dir: &tempfile::TempDir,
+    config: VelesConfig,
+) -> (Database, velesdb_core::VectorCollection) {
+    let db = Database::open_with_config(dir.path(), config).expect("test: reopen");
+    let collection = db.get_vector_collection("docs").expect("test: collection");
+    (db, collection)
+}
+
+/// A per-query `ef` does not depend on the configured default.
+///
+/// One persisted index, reopened under two DIFFERENT configured defaults, must
+/// give the same answer to the same explicit call -- if the default leaked into
+/// explicit searches the two would disagree. Same index on purpose: two indexes
+/// built separately can differ by construction and would make the equality
+/// flap for reasons unrelated to configuration.
+///
+/// The first draft compared an explicit call to ITSELF and labelled it a
+/// control, which could not fail, and asserted only that explicit and default
+/// answers differ, which a clamped `ef` satisfies (#2246, P2-b and P2-e). That
+/// an explicit `ef` is honoured at all is proven by the control of
+/// `a_configured_ef_search_reaches_an_unqualified_search`, which fails if
+/// `search_with_ef` ignores its argument.
 #[test]
-fn a_per_query_ef_still_overrides_the_configured_default() {
+fn a_per_query_ef_is_independent_of_the_configured_default() {
     let dir = tempfile::TempDir::new().expect("test: tempdir");
-    let collection = seeded(&dir, config_with_ef(LOW_EF));
+    seeded(&dir, VelesConfig::default())
+        .flush_full()
+        .expect("test: persist the index both opens will read");
     let query = vector(POINTS as u64 + 1);
-    assert_eq!(
-        ids(&collection
-            .search_with_ef(&query, K, HIGH_EF)
-            .expect("test: override")),
-        ids(&collection
-            .search_with_ef(&query, K, HIGH_EF)
-            .expect("test: override again")),
-        "CONTROL: the explicit path must be deterministic before it is compared"
-    );
+
+    let (db_low, low) = reopened(&dir, config_with_ef(LOW_EF));
+    let low_default = ids(&low.search(&query, K).expect("test: low default"));
+    let low_explicit = ids(&low
+        .search_with_ef(&query, K, HIGH_EF)
+        .expect("test: explicit"));
+    drop(low);
+    drop(db_low);
+
+    let (_db_high, high) = reopened(&dir, config_with_ef(HIGH_EF));
+    let high_default = ids(&high.search(&query, K).expect("test: high default"));
+    let high_explicit = ids(&high
+        .search_with_ef(&query, K, HIGH_EF)
+        .expect("test: explicit"));
+
     assert_ne!(
-        ids(&collection
-            .search_with_ef(&query, K, HIGH_EF)
-            .expect("test: override")),
-        ids(&collection
-            .search(&query, K)
-            .expect("test: configured default")),
-        "the per-query ef must not be flattened onto the configured one"
+        low_default, high_default,
+        "CONTROL: the two configured defaults must answer differently, or the \
+         equality below could not tell a leak from a default with no effect"
+    );
+    assert_eq!(
+        low_explicit, high_explicit,
+        "an explicit ef must give the same answer whatever default the collection was opened with"
     );
 }
 
-/// `perfect` is refused as a global default, with the reason.
+/// `perfect` as a global default still loads, and is applied as `accurate`.
+///
+/// This refused at load until the seven-lens review (#2246): a TOML accepted by
+/// v6.0.0 then failed `Database::open`, a breaking change shipped under
+/// `### Added`. The concern behind the refusal is kept -- a global `Perfect`
+/// would reach `search_with_optional_bitmap`, which cannot enforce
+/// `max_perfect_mode_vectors` -- by never letting the default resolve to it.
+///
+/// Asserted on the resolution because
+/// `a_configured_ef_search_reaches_an_unqualified_search` already proves the
+/// resolved quality is what `search()` runs; together they cover the path.
 #[test]
-fn perfect_is_refused_as_a_global_default() {
+fn perfect_as_a_global_default_still_opens_and_resolves_to_accurate() {
+    let dir = tempfile::TempDir::new().expect("test: tempdir");
+    let mut opening = VelesConfig::default();
+    opening.search.default_mode = SearchMode::Perfect;
+    Database::open_with_config(dir.path(), opening)
+        .expect("a config v6.0.0 accepted must keep opening a database");
+
     let mut config = VelesConfig::default();
     config.search.default_mode = SearchMode::Perfect;
-    let message = config
-        .validate()
-        .expect_err("an exhaustive scan cannot be the default for every query")
-        .to_string();
-    assert!(
-        message.contains("max_perfect_mode_vectors"),
-        "the refusal must name the guard that cannot be enforced, got: {message}"
+    assert_eq!(
+        config.search.resolved_quality(),
+        velesdb_core::SearchQuality::Accurate,
+        "a global `perfect` must never resolve to the exhaustive scan no path can cap"
     );
 
-    config.search.default_mode = SearchMode::Accurate;
-    assert!(
-        config.validate().is_ok(),
-        "CONTROL: only `perfect` is refused; the other modes must load"
+    config.search.default_mode = SearchMode::Balanced;
+    assert_eq!(
+        config.search.resolved_quality(),
+        velesdb_core::SearchQuality::Balanced,
+        "CONTROL: only `perfect` is downgraded; every other mode resolves to itself"
     );
 }

--- a/crates/velesdb-mobile/examples/velesdb.toml
+++ b/crates/velesdb-mobile/examples/velesdb.toml
@@ -33,7 +33,9 @@
 #   fast      ef_search 96,   ~95% recall
 #   balanced  ef_search 160,  ~99.5% recall — the default
 #   accurate  ef_search 512,  ~100% recall
-#   perfect   exhaustive brute force, 100% by construction, O(n)
+#   perfect   per query only: as a global default it is applied as
+#             accurate, with a warning at load -- an exhaustive scan
+#             cannot be capped on every search path
 default_mode = "balanced"
 
 # Hard cap on results per query.

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -46,13 +46,17 @@ To point at a file anywhere else, pass it explicitly:
 | `velesdb` (CLI) | `--config <path>` (global — REPL and every one-shot command) | `VELESDB_CONFIG` |
 
 > **What the engine actually applies.** `[limits]` is enforced at the
-> collection and ingest boundaries, and `[hnsw]`'s `m` / `ef_construction`
+> collection and ingest boundaries, `[hnsw]`'s `m` / `ef_construction`
 > are applied when a collection's index is created (see the precedence chain
-> under [Section \[hnsw\]](#section-hnsw)). Everything else below is parsed
-> and validated but **not** wired: `[search]`, `[quantization]`,
-> `hnsw.max_layers` and `storage.storage_mode` — each still pending its own
-> wiring decision (issue #2087). Setting any of these away from its default
-> logs a warning at load, naming exactly what is inert. Three more
+> under [Section \[hnsw\]](#section-hnsw)), and `[search]`'s `default_mode` /
+> `ef_search` set the quality of every search that does not name its own
+> (issue #2087 — `default_mode = "perfect"` is applied as `accurate`, with a
+> warning: an exhaustive scan cannot be a global default). Everything else
+> below is parsed and validated but **not** wired: `search.max_results`,
+> `search.query_timeout_ms`, `[quantization]`, `hnsw.max_layers` and
+> `storage.storage_mode` — each still pending its own decision. Setting any of
+> these away from its default logs a warning at load, naming exactly what is
+> inert. Three more
 > `[storage]` fields — `data_dir`, `mmap_cache_mb`, `vector_alignment` — are
 > not pending anything: no engine counterpart exists to wire them to, so
 > they are **deprecated** instead (their own warning, same treatment as
@@ -141,6 +145,8 @@ data_dir = "./data"
 [search]
 # Mode de recherche par défaut
 # Valeurs: "fast" | "balanced" | "accurate" | "perfect"
+# Note: "perfect" as a GLOBAL default is applied as "accurate", with a
+# warning at load -- request Perfect per query, where the cap applies.
 # Default: "balanced"
 default_mode = "balanced"
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*`-class change on a `docs/` branch → targets `develop`. ✅

## Description

**Lot P1 of #2246**, plus the parts of P2 and P4 that live in the same files.

### The policy: a global `perfect` is applied as `accurate`, not refused

#2242 made `search.default_mode = "perfect"` a **hard load error**. Three
reviewers flagged it independently, and they were right: a TOML v6.0.0 accepted
then failed `Database::open` — a breaking change in a minor release, filed under
`### Added`, against `config_validation.rs`'s own stated rule (*"Warn — rather
than reject — … so existing files keep loading"*). `cargo-semver-checks` cannot
see it: it reads signatures, not load contracts.

**The reason for refusing still holds, and is still honoured.** A global
`Perfect` would reach `search_with_optional_bitmap`, which returns
`Vec<ScoredResult>` and cannot enforce `limits.max_perfect_mode_vectors`. So
`resolved_quality()` never returns `Perfect`: the default is applied as
`Accurate`, and `validate()` says so. Per query, `search_with_quality(Perfect)`
stays available and capped.

### Folded in, because two PRs would collide on the same files

| lot | what |
|---|---|
| **P4-a** | `CONFIGURATION.md` declared `[search]` wholly inert; half of it has applied since #2242. The "what the engine applies" block now names which half, and the value list notes the downgrade. |
| **P2-b** | A block labelled `CONTROL` compared `search_with_ef(HIGH_EF)` **to itself** — it could not fail, in a file whose module doc promises every control is falsifiable. |
| **P2-e** | The override test only asserted *explicit ≠ default*, which a clamped `ef` satisfies. |
| **Perf-2** | The CHANGELOG's A/B claim: under a default config the resolved quality is `Balanced`, exactly what was hard-coded, so the six passes measured the plumbing and **could not see the wiring's real effect**. Now stated. |
| **Perf-3** | An upgrade note: a config that already set `default_mode`/`ef_search` starts applying them. The "Production - High Precision" profile moves an unqualified search from `160.max(k*5)` to `512.max(k*16)` candidates. |
| parity | The mobile and Tauri example configs listed `perfect` as "exhaustive brute force" for this field; they now say per-query only. |

P2-b and P2-e are replaced by **one** test: one persisted index, reopened under
two **different** configured defaults, must answer an explicit call identically.
Same index on purpose — two separately built graphs can differ by construction
and would make the equality flap for reasons unrelated to configuration. Its
control asserts the two defaults answer *differently*, or the equality could not
tell a leak from a default with no effect.

## RED first — two mutations

| mutation | caught by |
|---|---|
| a global `Perfect` re-resolved to `Perfect` | `perfect_as_a_global_default_still_opens_and_resolves_to_accurate` |
| the configured default leaking into `search_with_ef` | `a_per_query_ef_is_independent_of_the_configured_default` (and the first test's control) |

## How Has This Been Tested?

- [x] `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `cargo check --workspace --no-default-features --exclude velesdb-python` and the `wasm32-unknown-unknown` check — OK.
- [x] `cargo test --lib collection::` and `--lib config`, `--test search_config_defaults` — green.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — OK.
- [x] The two mutations above.

## Type of Change

- [x] 🐛 Bug fix — a minor release would have broken configs v6.0.0 accepted

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Touches the default search path's quality resolution. The only behavioural change
against `develop` is for a config setting `default_mode = "perfect"`, which now
opens instead of failing; every other config resolves exactly as before.

Refs #2246.
