### PR TITLE
test(guards): seven guards now check the premise they were checking a result against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arrived with the adoption rather than a latent defect. The index is now saved
   before the call returns, and `reorder_durability.rs` pins it — seen failing
   with the save removed.
+
 - **Seven guards verified their result and never their premise.** The worst
   reopened #2232 silently: `test_exactly_one_step_produces_the_verdict` matched
   `steps\.\w+\.conclusion`, any identifier, so renaming the mirror step's `id:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collinear one every mode satisfies; and the `.vectors` no-write test runs under
   Cosine, whose load path renormalises in place. Each was seen failing on the
   mutation it names (#2246, P2).
+
 - **`SearchQuality::Perfect` was documented as the opposite of what it does.**
   Its rustdoc described a graph search at `ef_search = 4096` that "tunes the
   HNSW graph's effort and is not exhaustive", with a ~0.9994 recall figure at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   load call alone reports the cost as gone when it has only moved.
 
 ### Fixed
+
+- **Seven guards verified their result and never their premise.** The worst
+  reopened #2232 silently: `test_exactly_one_step_produces_the_verdict` matched
+  `steps\.\w+\.conclusion`, any identifier, so renaming the mirror step's `id:`
+  without its reference left all 106 tests green while `CI Success` went green
+  reading no `needs` result — GitHub evaluates an unknown step id to `''`. The id
+  is now read from the mirror itself. Alongside it: the lockfile set and
+  `DEFERRED_REMOVALS` gained non-vacuity checks, so an empty set can no longer
+  satisfy "nothing is missing"; the attribution guard's issue surface must now be
+  refused before the absence of its push remedy counts; the duplicate-heading
+  guard covers `crates/velesdb-memory/CHANGELOG.md`, which `release-memory.yml`
+  publishes and nothing guarded; `perfect_mode_semantics` compares Perfect with a
+  brute-force ground truth on a dispersed fixture instead of `top1 == 7` on a
+  collinear one every mode satisfies; and the `.vectors` no-write test runs under
+  Cosine, whose load path renormalises in place. Each was seen failing on the
+  mutation it names (#2246, P2).
 - **`SearchQuality::Perfect` was documented as the opposite of what it does.**
   Its rustdoc described a graph search at `ef_search = 4096` that "tunes the
   HNSW graph's effort and is not exhaustive", with a ~0.9994 recall figure at

--- a/crates/velesdb-core/tests/perfect_mode_semantics.rs
+++ b/crates/velesdb-core/tests/perfect_mode_semantics.rs
@@ -20,6 +20,8 @@ const DIM: usize = 32;
 const POINTS: usize = 3_000;
 const K: usize = 10;
 const LOW_EF: usize = 16;
+/// Queries the CONTROL is taken over: one could come out exact by chance.
+const QUERIES: usize = 50;
 const CAP: usize = 10;
 
 const _: () = assert!(
@@ -113,32 +115,40 @@ fn perfect_quality_is_refused_above_the_configured_cap() {
 /// The first version asserted `top1 == 7` on a collinear fixture, which every
 /// mode satisfies: routing `Perfect` to a low-ef graph search would have left it
 /// green (#2246, P2-e). The answer is now compared with a ground truth computed
-/// here, after a CONTROL shows a low-ef graph search misses on this fixture.
+/// here, after a CONTROL shows a low-ef graph search misses on this fixture —
+/// on at least one of `QUERIES` queries, not on one: `search_with_ef` reranks
+/// `4 × k` candidates exactly and the graph is built by a parallel insert, so a
+/// single query can come out exact by chance and turn the control red.
 #[test]
 fn perfect_quality_runs_once_the_cap_allows_it_and_is_exact() {
     let dir = tempfile::TempDir::new().expect("test: tempdir");
     let collection = collection_with_cap(&dir, POINTS + 1);
-    let query = vector(POINTS as u64 + 1);
-    let truth = exact_top_k(&query, K);
     let ids = |hits: Vec<velesdb_core::SearchResult>| {
         hits.into_iter().map(|r| r.point.id).collect::<Vec<_>>()
     };
 
-    let graph = ids(collection
-        .search_with_ef(&query, K, LOW_EF)
-        .expect("test: low-ef graph search"));
-    assert_ne!(
-        graph, truth,
-        "CONTROL: a low-ef graph search must miss on this fixture, or the \
-         exactness asserted below would prove nothing about Perfect"
-    );
-
-    let perfect = ids(collection
-        .search_with_quality(&query, K, SearchQuality::Perfect)
-        .expect("test: Perfect under the cap must run"));
-    assert_eq!(
-        perfect, truth,
-        "Perfect must return the exact top-k, in order"
+    let mut graph_misses = 0;
+    for i in 0..QUERIES {
+        let query = vector((POINTS + 1 + i) as u64);
+        let truth = exact_top_k(&query, K);
+        let graph = ids(collection
+            .search_with_ef(&query, K, LOW_EF)
+            .expect("test: low-ef graph search"));
+        if graph != truth {
+            graph_misses += 1;
+        }
+        let perfect = ids(collection
+            .search_with_quality(&query, K, SearchQuality::Perfect)
+            .expect("test: Perfect under the cap must run"));
+        assert_eq!(
+            perfect, truth,
+            "Perfect must return the exact top-k, in order"
+        );
+    }
+    assert!(
+        graph_misses > 0,
+        "CONTROL: a low-ef graph search must miss on this fixture — on at least one of \
+         {QUERIES} queries — or the exactness asserted above would prove nothing about Perfect"
     );
 }
 

--- a/crates/velesdb-core/tests/perfect_mode_semantics.rs
+++ b/crates/velesdb-core/tests/perfect_mode_semantics.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "persistence")]
 #![allow(clippy::cast_precision_loss)] // ids into f32 coordinates, deliberately
-#![allow(clippy::cast_possible_truncation)] // usize ids into u64, on a 200-point fixture
+#![allow(clippy::cast_possible_truncation)] // usize ids into u64, on a 3 000-point fixture
 
 //! What `Perfect` means on each of the two axes, pinned.
 //!
@@ -16,14 +16,49 @@
 
 use velesdb_core::{Database, DistanceMetric, Point, SearchMode, SearchQuality, VelesConfig};
 
-const DIM: usize = 8;
-const POINTS: usize = 200;
+const DIM: usize = 32;
+const POINTS: usize = 3_000;
+const K: usize = 10;
+const LOW_EF: usize = 16;
 const CAP: usize = 10;
 
 const _: () = assert!(
     CAP < POINTS,
     "the cap must sit below the collection size or the guard rail cannot fire"
 );
+
+/// Deterministic, dispersed coordinates.
+///
+/// The first fixture was `vec![id as f32; DIM]`: every vector on one line, so
+/// the nearest neighbour of any query is the same for every search mode and an
+/// "exact" assertion could not tell a brute force from a graph (#2246, P2-e).
+fn vector(id: u64) -> Vec<f32> {
+    let mut x = id.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    (0..DIM)
+        .map(|_| {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            (x % 10_000) as f32 / 10_000.0
+        })
+        .collect()
+}
+
+/// The true top-`k` by Euclidean distance, computed here without the engine.
+fn exact_top_k(query: &[f32], k: usize) -> Vec<u64> {
+    let mut scored: Vec<(f32, u64)> = (0..POINTS as u64)
+        .map(|id| {
+            let d: f32 = vector(id)
+                .iter()
+                .zip(query)
+                .map(|(a, b)| (a - b) * (a - b))
+                .sum();
+            (d, id)
+        })
+        .collect();
+    scored.sort_by(|a, b| a.0.total_cmp(&b.0));
+    scored.into_iter().take(k).map(|(_, id)| id).collect()
+}
 
 fn collection_with_cap(dir: &tempfile::TempDir, cap: usize) -> velesdb_core::VectorCollection {
     let mut config = VelesConfig::default();
@@ -33,7 +68,7 @@ fn collection_with_cap(dir: &tempfile::TempDir, cap: usize) -> velesdb_core::Vec
         .expect("test: create");
     let collection = db.get_vector_collection("docs").expect("test: collection");
     let points: Vec<Point> = (0..POINTS)
-        .map(|id| Point::new(id as u64, vec![id as f32; DIM], None))
+        .map(|id| Point::new(id as u64, vector(id as u64), None))
         .collect();
     collection.upsert(points).expect("test: upsert");
     collection
@@ -73,22 +108,37 @@ fn perfect_quality_is_refused_above_the_configured_cap() {
     );
 }
 
-/// Raising the cap above the collection size lets the same call through.
+/// Raising the cap lets the call through, and what comes back is EXACT.
 ///
-/// Without this, the test above could pass on a collection that simply cannot
-/// answer a Perfect search at all.
+/// The first version asserted `top1 == 7` on a collinear fixture, which every
+/// mode satisfies: routing `Perfect` to a low-ef graph search would have left it
+/// green (#2246, P2-e). The answer is now compared with a ground truth computed
+/// here, after a CONTROL shows a low-ef graph search misses on this fixture.
 #[test]
-fn perfect_quality_runs_once_the_cap_allows_it() {
+fn perfect_quality_runs_once_the_cap_allows_it_and_is_exact() {
     let dir = tempfile::TempDir::new().expect("test: tempdir");
     let collection = collection_with_cap(&dir, POINTS + 1);
-    let hits = collection
-        .search_with_quality(&[7.0_f32; DIM], 5, SearchQuality::Perfect)
-        .expect("test: Perfect under the cap must run");
-    assert_eq!(hits.len(), 5, "an exhaustive scan still returns k results");
+    let query = vector(POINTS as u64 + 1);
+    let truth = exact_top_k(&query, K);
+    let ids = |hits: Vec<velesdb_core::SearchResult>| {
+        hits.into_iter().map(|r| r.point.id).collect::<Vec<_>>()
+    };
+
+    let graph = ids(collection
+        .search_with_ef(&query, K, LOW_EF)
+        .expect("test: low-ef graph search"));
+    assert_ne!(
+        graph, truth,
+        "CONTROL: a low-ef graph search must miss on this fixture, or the \
+         exactness asserted below would prove nothing about Perfect"
+    );
+
+    let perfect = ids(collection
+        .search_with_quality(&query, K, SearchQuality::Perfect)
+        .expect("test: Perfect under the cap must run"));
     assert_eq!(
-        hits.first().map(|r| r.point.id),
-        Some(7),
-        "and it returns the exact nearest neighbour"
+        perfect, truth,
+        "Perfect must return the exact top-k, in order"
     );
 }
 

--- a/crates/velesdb-core/tests/vectors_format_roundtrip.rs
+++ b/crates/velesdb-core/tests/vectors_format_roundtrip.rs
@@ -198,8 +198,13 @@ fn digest(path: &Path) -> u64 {
 
 /// Creates a collection holding `ids`, then closes the database.
 fn seed(dir: &TempDir, ids: std::ops::Range<u64>, mode: StorageMode) {
+    seed_with(dir, ids, mode, DistanceMetric::Euclidean);
+}
+
+/// [`seed`], with the metric chosen by the caller.
+fn seed_with(dir: &TempDir, ids: std::ops::Range<u64>, mode: StorageMode, metric: DistanceMetric) {
     let db = Database::open(dir.path()).expect("test: open database");
-    db.create_vector_collection_with_options("docs", DIM, DistanceMetric::Euclidean, mode)
+    db.create_vector_collection_with_options("docs", DIM, metric, mode)
         .expect("test: create collection");
     let collection = db
         .get_vector_collection("docs")
@@ -279,11 +284,22 @@ fn a_corrupt_vectors_file_does_not_prevent_opening() {
 /// shipped: its migration resume proves a source store unchanged by hashing
 /// these very files, so a store that grew on open made a correct resume look
 /// like a corrupted one.
+///
+/// Run under Cosine as well as Euclidean since #2246 (P2-f). The load path
+/// renormalises a cosine collection's vectors in place, on an arena that IS the
+/// durable file once adopted. It writes nothing today only because the vectors
+/// were already normalised at insert; the cosine arms are what would notice if
+/// that stopped being true.
 #[test]
 fn opening_a_collection_never_writes_to_its_vectors_file() {
-    for count in [SMALL, ADOPTED] {
+    for (metric, count) in [
+        (DistanceMetric::Euclidean, SMALL),
+        (DistanceMetric::Euclidean, ADOPTED),
+        (DistanceMetric::Cosine, SMALL),
+        (DistanceMetric::Cosine, ADOPTED),
+    ] {
         let dir = TempDir::new().expect("test: tempdir");
-        seed(&dir, 0..count, StorageMode::Full);
+        seed_with(&dir, 0..count, StorageMode::Full, metric);
         let file = vectors_file(dir.path());
         let before = digest(&file);
 
@@ -295,14 +311,14 @@ fn opening_a_collection_never_writes_to_its_vectors_file() {
             assert_eq!(
                 collection.len(),
                 usize::try_from(count).expect("test: count fits a usize"),
-                "test: the fixture did not load at {count} points"
+                "test: the fixture did not load at {count} points under {metric:?}"
             );
         }
 
         assert_eq!(
             digest(&file),
             before,
-            "test: opening a collection wrote to its .vectors at {count} points"
+            "test: opening a collection wrote to its .vectors at {count} points under {metric:?}"
         );
     }
 }

--- a/crates/velesdb-core/tests/vectors_format_roundtrip.rs
+++ b/crates/velesdb-core/tests/vectors_format_roundtrip.rs
@@ -288,8 +288,9 @@ fn a_corrupt_vectors_file_does_not_prevent_opening() {
 /// Run under Cosine as well as Euclidean since #2246 (P2-f). The load path
 /// renormalises a cosine collection's vectors in place, on an arena that IS the
 /// durable file once adopted. It writes nothing today only because the vectors
-/// were already normalised at insert; the cosine arms are what would notice if
-/// that stopped being true.
+/// were normalised at insert, inside the load's 1e-5 tolerance. Only the
+/// (Cosine, ADOPTED) arm can notice if that stops being true: below the
+/// capacity floor the copy path normalises a heap copy, never the file.
 #[test]
 fn opening_a_collection_never_writes_to_its_vectors_file() {
     for (metric, count) in [

--- a/scripts/tests/test_changelog_release_notes.py
+++ b/scripts/tests/test_changelog_release_notes.py
@@ -157,23 +157,25 @@ class UnreleasedSectionTests(unittest.TestCase):
     #: that does it. The first version guarded only the root file; the one
     #: `release-memory.yml` publishes was guarded by nothing (#2246, P2-d).
     PUBLISHED = {
-        "CHANGELOG.md": "release.yml",
-        "crates/velesdb-memory/CHANGELOG.md": "release-memory.yml",
+        ROOT / "CHANGELOG.md": "release.yml",
+        MEMORY_CHANGELOG: "release-memory.yml",
     }
 
     def setUp(self) -> None:
         self.text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
     def test_no_type_appears_twice(self) -> None:
-        for rel, workflow in self.PUBLISHED.items():
-            with self.subTest(changelog=rel):
-                headings = unreleased_headings((ROOT / rel).read_text(encoding="utf-8"))
+        for path, workflow in self.PUBLISHED.items():
+            rel = path.relative_to(ROOT)
+            with self.subTest(changelog=str(rel)):
+                headings = unreleased_headings(path.read_text(encoding="utf-8"))
                 duplicated = sorted({h for h in headings if headings.count(h) > 1})
                 self.assertEqual(
                     duplicated,
                     [],
-                    f"`## [Unreleased]` of {rel} repeats {duplicated}, and {workflow} "
-                    "publishes that block as release notes. Merge each type into one section.",
+                    f"`## [Unreleased]` of {rel} repeats {duplicated}; at release this "
+                    f"block becomes the version section {workflow} turns into release "
+                    "notes. Merge each type into one section.",
                 )
 
     def test_the_block_has_headings_at_all(self) -> None:

--- a/scripts/tests/test_changelog_release_notes.py
+++ b/scripts/tests/test_changelog_release_notes.py
@@ -153,18 +153,28 @@ class UnreleasedSectionTests(unittest.TestCase):
     while the cleanup PR was still in review. Hence a guard rather than a sweep.
     """
 
+    #: Each changelog a release workflow publishes a section of, and the workflow
+    #: that does it. The first version guarded only the root file; the one
+    #: `release-memory.yml` publishes was guarded by nothing (#2246, P2-d).
+    PUBLISHED = {
+        "CHANGELOG.md": "release.yml",
+        "crates/velesdb-memory/CHANGELOG.md": "release-memory.yml",
+    }
+
     def setUp(self) -> None:
         self.text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
     def test_no_type_appears_twice(self) -> None:
-        headings = unreleased_headings(self.text)
-        duplicated = sorted({h for h in headings if headings.count(h) > 1})
-        self.assertEqual(
-            duplicated,
-            [],
-            f"`## [Unreleased]` repeats {duplicated}. Merge each type into one "
-            "section; the release notes are generated from this block.",
-        )
+        for rel, workflow in self.PUBLISHED.items():
+            with self.subTest(changelog=rel):
+                headings = unreleased_headings((ROOT / rel).read_text(encoding="utf-8"))
+                duplicated = sorted({h for h in headings if headings.count(h) > 1})
+                self.assertEqual(
+                    duplicated,
+                    [],
+                    f"`## [Unreleased]` of {rel} repeats {duplicated}, and {workflow} "
+                    "publishes that block as release notes. Merge each type into one section.",
+                )
 
     def test_the_block_has_headings_at_all(self) -> None:
         """Otherwise an empty parse would satisfy the test above forever."""

--- a/scripts/tests/test_check_ai_attribution.py
+++ b/scripts/tests/test_check_ai_attribution.py
@@ -337,8 +337,22 @@ class RemedyTests(unittest.TestCase):
                 self.assertIn("CI Success", message)
 
     def test_a_non_pull_request_surface_is_not(self) -> None:
-        """The push half is specific to the required-chain gap, not general."""
-        self.assertNotIn("PUSH", self._stderr("issue"))
+        """The push half is specific to the required-chain gap, not general.
+
+        Asserting only that "PUSH" is absent passed on an EMPTY stderr, so a
+        change that stopped auditing the issue surface altogether would have
+        left this green (#2246, P2-c). The refusal itself is required first.
+        """
+        message = self._stderr("issue")
+        # The violation line goes to STDOUT and the remedy to stderr, so the
+        # remedy is what proves the surface was refused on this stream.
+        self.assertIn(
+            "Edit the issue",
+            message,
+            "the issue surface must still be refused -- and told how to fix it -- "
+            "before the absence of the push step means anything",
+        )
+        self.assertNotIn("PUSH", message)
 
 
 class SingleSourceTests(unittest.TestCase):

--- a/scripts/tests/test_check_deferred_removals.py
+++ b/scripts/tests/test_check_deferred_removals.py
@@ -173,6 +173,11 @@ class RealTreeTests(unittest.TestCase):
     def test_every_listed_site_exists_today(self) -> None:
         # A site that never matches is a guard watching nothing: the removal
         # would "pass" the day the major arrives while the code is untouched.
+        self.assertTrue(
+            guard.DEFERRED_REMOVALS,
+            "DEFERRED_REMOVALS is empty: the loop below checks nothing and passes "
+            "(#2246, P2-c)",
+        )
         for entry in guard.DEFERRED_REMOVALS:
             with self.subTest(what=entry["what"]):
                 self.assertEqual(

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -1599,8 +1599,9 @@ def mirror_binding(text: str) -> "tuple[str | None, bool]":
         return None, False
     chain = next((s for s in steps if "Check results" in s), "")
     bound = re.search(
-        rf"if:\s*steps\.{re.escape(declared.group(1))}\.conclusion\s*==\s*'skipped'",
+        rf"^\s*if:\s*steps\.{re.escape(declared.group(1))}\.conclusion\s*==\s*'skipped'\s*$",
         chain,
+        re.M,
     )
     return declared.group(1), bound is not None
 
@@ -1742,6 +1743,16 @@ jobs:
 
     def test_the_binding_holds_when_the_ids_match(self) -> None:
         self.assertEqual(mirror_binding(self.SYNTHETIC), ("mirror", True))
+
+    def test_a_condition_widened_past_the_mirror_breaks_the_binding(self) -> None:
+        """`|| always()` after the skip test runs the chain on every edit too:
+        two steps would then produce a verdict, which is what this binding
+        exists to rule out. An unanchored match read it as bound."""
+        widened = self.SYNTHETIC.replace(
+            "conclusion == 'skipped'", "conclusion == 'skipped' || always()"
+        )
+        self.assertNotEqual(widened, self.SYNTHETIC, "CONTROL: the fixture carries the condition")
+        self.assertEqual(mirror_binding(widened), ("mirror", False))
 
     def test_a_renamed_mirror_id_breaks_the_binding(self) -> None:
         renamed = self.SYNTHETIC.replace("id: mirror", "id: mirror_verdict")

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -1584,6 +1584,27 @@ def ci_success_steps(text: str) -> "list[str]":
     return [("- name:" + s) for s in steps[1:]]
 
 
+def mirror_binding(text: str) -> "tuple[str | None, bool]":
+    """(the id the mirror step declares, whether `Check results` reads THAT id).
+
+    GitHub evaluates `steps.<unknown>.conclusion` to '' rather than failing, so
+    a reference that no longer matches the declared id silences the chain
+    instead of breaking it. Only reading the id from the mirror itself catches
+    the drift.
+    """
+    steps = ci_success_steps(text)
+    mirror = next((s for s in steps if NO_OP_EDIT_RE.search(s)), "")
+    declared = re.search(r"^\s*id:\s*([\w-]+)\s*$", mirror, re.M)
+    if declared is None:
+        return None, False
+    chain = next((s for s in steps if "Check results" in s), "")
+    bound = re.search(
+        rf"if:\s*steps\.{re.escape(declared.group(1))}\.conclusion\s*==\s*'skipped'",
+        chain,
+    )
+    return declared.group(1), bound is not None
+
+
 class NoOpEditCannotProduceAGreenCheckTests(unittest.TestCase):
     """`CI Success` never reports a verdict no execution produced.
 
@@ -1660,14 +1681,23 @@ class NoOpEditCannotProduceAGreenCheckTests(unittest.TestCase):
                 )
 
     def test_exactly_one_step_produces_the_verdict(self) -> None:
-        """The chain must stand down when the mirror ran, and only then."""
-        chain = next(s for s in self.steps if "Check results" in s)
-        self.assertRegex(
-            chain,
-            r"if:\s*steps\.\w+\.conclusion\s*==\s*'skipped'",
-            "the `Check results` step must be conditioned on the mirror having "
-            "skipped; unconditional, it asserts over skipped needs and turns every "
-            "description edit red",
+        """The chain stands down exactly when the MIRROR ran — bound by its id.
+
+        The first version matched `steps\.\w+\.conclusion`, any identifier.
+        Renaming the mirror's `id:` without its reference then made the
+        reference evaluate to '', so `Check results` never ran and `CI Success`
+        went green having read no `needs` result — #2232 reopened, with every
+        test in this class green (#2246, P2-a, shown by mutation). The id is now
+        read from the mirror step itself.
+        """
+        ident, bound = mirror_binding(self.ci)
+        self.assertIsNotNone(
+            ident, "the mirror step declares no `id:`, so nothing can reference its conclusion"
+        )
+        self.assertTrue(
+            bound,
+            f"`Check results` must be conditioned on `steps.{ident}.conclusion`, the id "
+            "the mirror declares; any other identifier evaluates to '' and silences the chain",
         )
 
     def test_the_two_conditions_are_exact_negations(self) -> None:
@@ -1691,6 +1721,7 @@ jobs:
     if: always()
     steps:
       - name: Mirror
+        id: mirror
         if: github.event.action == 'edited' && github.event.changes.base == null
         run: exit 1
       - name: Check results
@@ -1708,6 +1739,13 @@ jobs:
 
     def test_the_no_op_condition_is_recognised(self) -> None:
         self.assertRegex(ci_success_steps(self.SYNTHETIC)[0], NO_OP_EDIT_RE)
+
+    def test_the_binding_holds_when_the_ids_match(self) -> None:
+        self.assertEqual(mirror_binding(self.SYNTHETIC), ("mirror", True))
+
+    def test_a_renamed_mirror_id_breaks_the_binding(self) -> None:
+        renamed = self.SYNTHETIC.replace("id: mirror", "id: mirror_verdict")
+        self.assertEqual(mirror_binding(renamed), ("mirror_verdict", False))
 
     def test_a_missing_condition_is_detected(self) -> None:
         without = self.SYNTHETIC.replace(

--- a/scripts/tests/test_npm_audit_gate.py
+++ b/scripts/tests/test_npm_audit_gate.py
@@ -391,7 +391,14 @@ class WiringTests(unittest.TestCase):
         day someone adds a ninth lockfile and forgets the matrix. The set is
         compared to what git tracks.
         """
-        unaudited = sorted(_tracked_lockfile_roots() - set(_matrix_paths()))
+        tracked = _tracked_lockfile_roots()
+        self.assertTrue(
+            tracked,
+            "git tracks no package-lock.json at all: the pathspec stopped matching, "
+            "and an empty set would make the difference below empty and this test "
+            "green while nothing is audited (#2246, P2-c)",
+        )
+        unaudited = sorted(tracked - set(_matrix_paths()))
         self.assertEqual(
             unaudited,
             [],


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`test/*` → targets `develop`. ✅

## Description

**Lot P2 of #2246.** Seven guards that could pass while the property they name
was false — the session's dominant defect, *the result is verified, the premise
never* — found by the testing lens of the review, and one of them in the guard I
wrote to close #2232.

| # | guard | how it could pass while wrong | mutation that now fails it |
|---|---|---|---|
| **a** | `test_exactly_one_step_produces_the_verdict` | matched `steps\.\w+\.conclusion` — *any* id. GitHub evaluates an unknown step id to `''`, so renaming the mirror's `id:` left `Check results` never running and `CI Success` green on nothing: **#2232 reopened, 106 tests green** | rename the id |
| c1 | `test_every_tracked_lockfile_is_audited` | an empty tracked set empties the difference | no lockfile tracked |
| c2 | `test_every_listed_site_exists_today` | a loop over a list that can be emptied | empty `DEFERRED_REMOVALS` (×4) |
| c3 | `test_a_non_pull_request_surface_is_not` | asserted only that `PUSH` was absent; an empty stderr satisfies it | a clean trailer |
| d | `UnreleasedSectionTests` | read only the root CHANGELOG; `release-memory.yml` publishes the memory one, guarded by nothing | a duplicated heading there |
| e | `perfect_mode_semantics` | `top1 == 7` on a collinear fixture every mode satisfies | route `Perfect` to a graph search at ef=16 |
| f | the `.vectors` no-write test | Euclidean only; cosine renormalises in place on the durable arena | scale on open → the cosine arms |

**a** was proven by mutation *before* the fix, as the review's centrepiece: rename
`id: mirror` → `mirror_verdict`, leave `steps.mirror.conclusion`, 106 tests OK.

**c3** is worth a line of its own: my first fix asserted `"violation"` in stderr
and failed on the real code. The issue surface *was* refused — on stdout. The
remedy is what goes to stderr, and that is what the test now requires.

**e** carries its own control: a low-ef graph search must *miss* the ground truth
on the fixture, or the exactness assertion would prove nothing about `Perfect`.

## How Has This Been Tested?

- [x] Every row above: the mutation run, FAILED observed, restored.
- [x] `cargo test -p velesdb-core --features persistence --test perfect_mode_semantics --test vectors_format_roundtrip` — green.
- [x] `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- [x] `python -m unittest discover -s scripts/tests -p "test_*.py" -t . ` — OK.

## Type of Change

- [x] ✅ Test coverage — guards that could not fail on the defect they name

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — tests and one CHANGELOG entry. No production code changes.

Refs #2246.
