### PR TITLE
test(memory): pay pwsh's cold start once, outside every installer test's budget

### DIFF
--- a/scripts/tests/test_install_memory_daemon.py
+++ b/scripts/tests/test_install_memory_daemon.py
@@ -8,6 +8,7 @@ developer's actual Codex configuration.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import shutil
@@ -15,13 +16,72 @@ import stat
 import subprocess
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SHELL_INSTALLER = REPO_ROOT / "scripts" / "install-memory-daemon.sh"
 POWERSHELL_INSTALLER = REPO_ROOT / "scripts" / "install-memory-daemon.ps1"
+
+# A pwsh launch is called hung once it outlasts this many start-ups of pwsh
+# on the same machine. A steady installer launch costs 2 to 4 of them and a
+# busy one up to 12, but on a loaded machine one launch ran past 50 while
+# the start-ups timed seconds before it read 0.25 s: a burst can land
+# between the measurement and the launch. 200 leaves four times that.
+PWSH_BUDGET_IN_STARTUPS = 200
+# Deadline of the one launch no budget covers: the cold start below, on
+# which run 34503494842 spent over 40 s across the launch it killed and the
+# next one.
+PWSH_COLD_START_DEADLINE = 120
+
+
+def pwsh_argv(pwsh: str, command: str) -> list[str]:
+    """The one pwsh command line of this suite: calibration and tests share it."""
+    return [pwsh, "-NoProfile", "-NonInteractive", "-Command", command]
+
+
+def _time_pwsh_start(pwsh: str) -> float:
+    """Seconds pwsh takes to start and exit, in a fresh HOME like each test's.
+
+    HOME holds PowerShell's start-up JIT profile, so a reused one would time
+    a faster start than any test launch gets.
+    """
+    with tempfile.TemporaryDirectory(prefix="pwsh-start-") as home:
+        began = time.monotonic()
+        subprocess.run(
+            pwsh_argv(pwsh, "exit 0"),
+            env={**os.environ, "HOME": home},
+            capture_output=True,
+            timeout=PWSH_COLD_START_DEADLINE,
+            check=True,
+        )
+        return time.monotonic() - began
+
+
+@functools.cache
+def pwsh_launch_budget(pwsh: str) -> float | None:
+    """Seconds one pwsh launch may take here, or None if pwsh never started.
+
+    The first pwsh launch on a fresh machine pays a one-time start-up cost
+    that has nothing to do with the installer. On GitHub's ubuntu-24.04
+    runners the first pwsh test of this suite took 2.9 to 19.9 s in six green
+    runs and every later one 0.8 to 1.8 s -- the same installer, in an
+    equally fresh HOME. In run 34503494842 the first ran past its 30 s
+    timeout and the next still took 12.3 s. So the cold start is paid here,
+    once, outside every test's budget, and the budget is derived from the
+    warm start-ups that follow it: a loaded machine starts pwsh slowly and
+    gets a proportionally longer budget. The slowest of three is used, so one
+    lucky sample cannot shrink it.
+    """
+    try:
+        _time_pwsh_start(pwsh)  # the cold start, kept out of every budget
+        warm = max(_time_pwsh_start(pwsh) for _ in range(3))
+    except subprocess.TimeoutExpired:
+        return None
+    return PWSH_BUDGET_IN_STARTUPS * warm
 
 
 class InstallerHarness(unittest.TestCase):
@@ -120,9 +180,6 @@ class InstallerHarness(unittest.TestCase):
         )
 
     def run_powershell(self, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
-        pwsh = shutil.which("pwsh")
-        if pwsh is None:
-            self.skipTest("pwsh is not installed")
         quoted_path = str(POWERSHELL_INSTALLER).replace("'", "''")
         skipped = ",".join(f"'{name}'" for name in self.skipped_clients())
         command = (
@@ -130,21 +187,57 @@ class InstallerHarness(unittest.TestCase):
             f"& '{quoted_path}' -WireOnly -SkipCaTrust "
             f"-SkipClient @({skipped})"
         )
-        return subprocess.run(
-            [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
-            cwd=REPO_ROOT,
-            env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=30,
-            check=False,
-        )
+        return self.run_pwsh(command, env)
+
+    def run_pwsh(
+        self, command: str, env: dict[str, str]
+    ) -> subprocess.CompletedProcess[str]:
+        pwsh = shutil.which("pwsh")
+        if pwsh is None:
+            self.skipTest("pwsh is not installed")
+        budget = pwsh_launch_budget(pwsh)
+        if budget is None:
+            self.fail(f"pwsh did not start within {PWSH_COLD_START_DEADLINE} s")
+        try:
+            return subprocess.run(
+                pwsh_argv(pwsh, command),
+                cwd=REPO_ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=budget,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as hung:
+            output = (hung.output or b"").decode(errors="replace")
+            self.fail(
+                f"pwsh ran past its {budget:.1f} s budget "
+                f"({PWSH_BUDGET_IN_STARTUPS}x its start-up here):\n{output}"
+            )
 
     def invocation_log(self) -> list[str]:
         if not self.log.exists():
             return []
         return self.log.read_text(encoding="utf-8").splitlines()
+
+
+class PwshLaunchBudgetTests(InstallerHarness):
+    def test_a_launch_past_its_budget_fails_instead_of_hanging(self) -> None:
+        with mock.patch(f"{__name__}.pwsh_launch_budget", return_value=2.0):
+            with self.assertRaisesRegex(AssertionError, r"past its 2\.0 s budget"):
+                self.run_pwsh("Start-Sleep -Seconds 60", self.environment())
+
+    def test_a_pwsh_that_never_started_fails_the_launch(self) -> None:
+        with mock.patch(f"{__name__}.pwsh_launch_budget", return_value=None):
+            with self.assertRaisesRegex(AssertionError, "did not start within"):
+                self.run_pwsh("exit 0", self.environment())
+
+    def test_the_cold_start_is_kept_out_of_the_budget(self) -> None:
+        starts = [45.0, 0.3, 0.2, 0.25]  # cold, then three warm
+        with mock.patch(f"{__name__}._time_pwsh_start", side_effect=starts):
+            budget = pwsh_launch_budget.__wrapped__("pwsh")
+        self.assertEqual(budget, PWSH_BUDGET_IN_STARTUPS * 0.3)
 
 
 class ShellCodexWiringTests(InstallerHarness):
@@ -262,9 +355,6 @@ class PowerShellClaudeWiringTests(InstallerHarness):
         )
         env = self.environment()
         env["FAKE_CLAUDE_LOG"] = str(claude_log)
-        pwsh = shutil.which("pwsh")
-        if pwsh is None:
-            self.skipTest("pwsh is not installed")
         quoted_path = str(POWERSHELL_INSTALLER).replace("'", "''")
         command = (
             "$PSNativeCommandUseErrorActionPreference = $true; "
@@ -272,16 +362,7 @@ class PowerShellClaudeWiringTests(InstallerHarness):
             "-SkipClient @('codex','claude-desktop','windsurf','devin')"
         )
 
-        result = subprocess.run(
-            [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
-            cwd=REPO_ROOT,
-            env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=30,
-            check=False,
-        )
+        result = self.run_pwsh(command, env)
 
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertEqual(
@@ -297,9 +378,6 @@ class PowerShellClaudeWiringTests(InstallerHarness):
 
 class PowerShellUninstallTests(InstallerHarness):
     def test_failed_native_removals_do_not_skip_json_cleanup(self) -> None:
-        pwsh = shutil.which("pwsh")
-        if pwsh is None:
-            self.skipTest("pwsh is not installed")
         self._write_executable("claude", "#!/bin/sh\nexit 41\n")
         desktop_dir = self.root / "appdata" / "Claude"
         desktop_dir.mkdir(parents=True)
@@ -328,16 +406,7 @@ class PowerShellUninstallTests(InstallerHarness):
                     f"& '{quoted_path}' -Uninstall"
                 )
 
-                result = subprocess.run(
-                    [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
-                    cwd=REPO_ROOT,
-                    env=env,
-                    text=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    timeout=30,
-                    check=False,
-                )
+                result = self.run_pwsh(command, env)
 
                 self.assertEqual(result.returncode, 0, result.stdout)
                 after = json.loads(config.read_text(encoding="utf-8"))
@@ -409,10 +478,6 @@ class DesktopBridgeContractTests(InstallerHarness):
         self.assertNotIn("NODE_TLS_REJECT_UNAUTHORIZED", entry["env"])
 
     def test_powershell_installer_writes_the_same_pinned_bridge(self) -> None:
-        pwsh = shutil.which("pwsh")
-        if pwsh is None:
-            self.skipTest("pwsh is not installed")
-
         fake_npx = self._write_executable("npx.cmd", "#!/bin/sh\nexit 99\n")
         self._write_fake_node("node.exe")
         self._write_executable("mcp-remote.cmd", "#!/bin/sh\nexit 98\n")
@@ -427,16 +492,7 @@ class DesktopBridgeContractTests(InstallerHarness):
             f"& '{quoted_path}' -WireOnly -SkipCaTrust "
             "-SkipClient @('claude-code','codex','windsurf','devin')"
         )
-        result = subprocess.run(
-            [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
-            cwd=REPO_ROOT,
-            env=self.environment(),
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=30,
-            check=False,
-        )
+        result = self.run_pwsh(command, self.environment())
 
         self.assertEqual(result.returncode, 0, result.stdout)
         entry = json.loads(config.read_text(encoding="utf-8"))["mcpServers"][
@@ -495,9 +551,6 @@ class DesktopBridgeContractTests(InstallerHarness):
         self.assertIn("Refusing to wire Claude Desktop", result.stdout)
 
     def test_powershell_installer_refuses_disabled_tls_verification(self) -> None:
-        pwsh = shutil.which("pwsh")
-        if pwsh is None:
-            self.skipTest("pwsh is not installed")
         self._write_executable("npx.cmd", "#!/bin/sh\nexit 99\n")
         self._write_fake_node("node.exe")
         desktop_dir = self.root / "appdata" / "Claude"
@@ -513,16 +566,7 @@ class DesktopBridgeContractTests(InstallerHarness):
             f"& '{quoted_path}' -WireOnly -SkipCaTrust "
             "-SkipClient @('claude-code','codex','windsurf','devin')"
         )
-        result = subprocess.run(
-            [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
-            cwd=REPO_ROOT,
-            env=env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=30,
-            check=False,
-        )
+        result = self.run_pwsh(command, env)
 
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertEqual(json.loads(config.read_text(encoding="utf-8")), {})
@@ -561,9 +605,6 @@ class DesktopBridgeContractTests(InstallerHarness):
         self.assertIn("minimum 20.18.1", result.stdout)
 
     def test_powershell_installer_refuses_unsupported_node(self) -> None:
-        pwsh = shutil.which("pwsh")
-        if pwsh is None:
-            self.skipTest("pwsh is not installed")
         self._write_executable("npx.cmd", "#!/bin/sh\nexit 99\n")
         self._write_fake_node("node.exe", "v18.20.8")
         desktop_dir = self.root / "appdata" / "Claude"
@@ -577,16 +618,7 @@ class DesktopBridgeContractTests(InstallerHarness):
             f"& '{quoted_path}' -WireOnly -SkipCaTrust "
             "-SkipClient @('claude-code','codex','windsurf','devin')"
         )
-        result = subprocess.run(
-            [pwsh, "-NoProfile", "-NonInteractive", "-Command", command],
-            cwd=REPO_ROOT,
-            env=self.environment(),
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            timeout=30,
-            check=False,
-        )
+        result = self.run_pwsh(command, self.environment())
 
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertEqual(json.loads(config.read_text(encoding="utf-8")), {})

--- a/scripts/tests/test_install_memory_daemon.py
+++ b/scripts/tests/test_install_memory_daemon.py
@@ -35,9 +35,9 @@ POWERSHELL_INSTALLER = REPO_ROOT / "scripts" / "install-memory-daemon.ps1"
 # the start-ups timed seconds before it read 0.25 s: a burst can land
 # between the measurement and the launch. 200 leaves four times that.
 PWSH_BUDGET_IN_STARTUPS = 200
-# Deadline of the one launch no budget covers: the cold start below, on
-# which run 34503494842 spent over 40 s across the launch it killed and the
-# next one.
+# Deadline of each calibration start-up below, which no budget covers yet.
+# The cold one is the slow one: run 34503494842 spent over 40 s across the
+# launch it killed and the next one.
 PWSH_COLD_START_DEADLINE = 120
 # The least and the most one launch may take, whatever the start-ups read:
 # the floor is the 30 s every launch had before the budget existed, and the
@@ -69,6 +69,11 @@ def _time_pwsh_start(pwsh: str) -> float:
         return time.monotonic() - began
 
 
+def _stderr(failure: subprocess.TimeoutExpired | subprocess.CalledProcessError) -> str:
+    """What a pwsh start-up wrote to stderr before it failed, as text."""
+    return (failure.stderr or b"").decode(errors="replace")
+
+
 @functools.cache
 def pwsh_launch_budget(pwsh: str) -> float | str:
     """Seconds one pwsh launch may take here, or why pwsh could not be timed.
@@ -90,11 +95,10 @@ def pwsh_launch_budget(pwsh: str) -> float | str:
     try:
         _time_pwsh_start(pwsh)  # the cold start, kept out of every budget
         warm = max(_time_pwsh_start(pwsh) for _ in range(3))
-    except subprocess.TimeoutExpired:
-        return f"pwsh did not start within {PWSH_COLD_START_DEADLINE} s"
+    except subprocess.TimeoutExpired as hung:
+        return f"pwsh did not start within {hung.timeout:g} s:\n{_stderr(hung)}"
     except subprocess.CalledProcessError as failed:
-        stderr = (failed.stderr or b"").decode(errors="replace")
-        return f"pwsh exited {failed.returncode} on start-up:\n{stderr}"
+        return f"pwsh exited {failed.returncode} on start-up:\n{_stderr(failed)}"
     except OSError as unrunnable:
         return f"pwsh could not be run: {unrunnable}"
     budget = min(
@@ -250,6 +254,20 @@ class PwshLaunchBudgetTests(InstallerHarness):
             with self.assertRaisesRegex(AssertionError, r"past its 2\.0 s budget"):
                 self.run_pwsh("Start-Sleep -Seconds 60", self.environment())
 
+    def test_a_launch_past_its_budget_shows_its_output_so_far(self) -> None:
+        """What the launch printed before its budget ran out is in the failure.
+
+        The launch is mocked: a real pwsh's first start-up can outlast any
+        budget short enough to test, and would print nothing before it.
+        """
+        hung = subprocess.TimeoutExpired("pwsh", 2.0, output=b"out-2272\n")
+        with mock.patch(f"{__name__}.pwsh_launch_budget", return_value=2.0):
+            with mock.patch(f"{__name__}.subprocess.run", side_effect=hung):
+                with self.assertRaisesRegex(
+                    AssertionError, r"past its 2\.0 s budget:\nout-2272"
+                ):
+                    self.run_pwsh("Start-Sleep -Seconds 60", self.environment())
+
     def test_a_pwsh_that_could_not_be_timed_fails_the_launch(self) -> None:
         reason = f"pwsh did not start within {PWSH_COLD_START_DEADLINE} s"
         with mock.patch(f"{__name__}.pwsh_launch_budget", return_value=reason):
@@ -257,7 +275,9 @@ class PwshLaunchBudgetTests(InstallerHarness):
                 self.run_pwsh("exit 0", self.environment())
 
     def test_the_cold_start_is_kept_out_of_the_budget(self) -> None:
-        starts = [45.0, 0.2, 0.25, 0.3]  # cold, then three warm, slowest last
+        """The cold sample never enters the budget, and the slowest warm one,
+        neither the first nor the last, sets it."""
+        starts = [45.0, 0.2, 0.3, 0.25]  # cold, then three warm, slowest in the middle
         printed = io.StringIO()
         with mock.patch(f"{__name__}._time_pwsh_start", side_effect=starts) as start:
             with contextlib.redirect_stderr(printed):
@@ -276,8 +296,14 @@ class PwshLaunchBudgetTests(InstallerHarness):
 
     def test_a_start_up_that_fails_is_reported_with_its_cause(self) -> None:
         for failure, message in [
-            (subprocess.TimeoutExpired("pwsh", PWSH_COLD_START_DEADLINE), "did not start within 120 s"),
-            (subprocess.CalledProcessError(1, "pwsh", stderr=b"no libicu"), "exited 1 on start-up:\nno libicu"),
+            (
+                subprocess.TimeoutExpired("pwsh", 7, stderr=b"no libicu"),
+                "did not start within 7 s:\nno libicu",
+            ),
+            (
+                subprocess.CalledProcessError(1, "pwsh", stderr=b"no libicu"),
+                "exited 1 on start-up:\nno libicu",
+            ),
             (FileNotFoundError(2, "No such file"), "could not be run"),
         ]:
             with mock.patch(f"{__name__}._time_pwsh_start", side_effect=failure):
@@ -292,6 +318,25 @@ class PwshLaunchBudgetTests(InstallerHarness):
             again = pwsh_launch_budget(unrunnable)
         self.assertEqual(start.call_count, 1)
         self.assertEqual(again, first)
+
+    def test_each_start_up_runs_in_a_fresh_home_under_its_deadline(self) -> None:
+        homes = []
+
+        def record(argv, **kwargs):
+            home = kwargs["env"]["HOME"]
+            homes.append(home)
+            self.assertTrue(Path(home).is_dir())
+            self.assertEqual(argv, pwsh_argv("pwsh", "exit 0"))
+            self.assertEqual(kwargs["timeout"], PWSH_COLD_START_DEADLINE)
+            self.assertIs(kwargs["check"], True)
+            self.assertIs(kwargs["capture_output"], True)
+            return subprocess.CompletedProcess(argv, 0)
+
+        with mock.patch(f"{__name__}.subprocess.run", side_effect=record):
+            _time_pwsh_start("pwsh")
+            _time_pwsh_start("pwsh")
+        self.assertEqual(len(set(homes)), 2)
+        self.assertNotIn(os.environ.get("HOME"), homes)
 
 
 class ShellCodexWiringTests(InstallerHarness):

--- a/scripts/tests/test_install_memory_daemon.py
+++ b/scripts/tests/test_install_memory_daemon.py
@@ -275,16 +275,18 @@ class PwshLaunchBudgetTests(InstallerHarness):
                 self.run_pwsh("exit 0", self.environment())
 
     def test_the_cold_start_is_kept_out_of_the_budget(self) -> None:
-        """The cold sample never enters the budget, and the slowest warm one,
-        neither the first nor the last, sets it."""
-        starts = [45.0, 0.2, 0.3, 0.25]  # cold, then three warm, slowest in the middle
-        printed = io.StringIO()
-        with mock.patch(f"{__name__}._time_pwsh_start", side_effect=starts) as start:
-            with contextlib.redirect_stderr(printed):
-                budget = pwsh_launch_budget.__wrapped__("pwsh")
-        self.assertEqual(start.call_count, 4)
-        self.assertEqual(budget, PWSH_BUDGET_IN_STARTUPS * 0.3)
-        self.assertIn(f"pwsh launch budget: {budget:.1f} s", printed.getvalue())
+        """The cold sample never enters the budget, and the slowest warm one sets
+        it, wherever it falls among the three."""
+        for warm in ([0.3, 0.2, 0.25], [0.2, 0.3, 0.25], [0.2, 0.25, 0.3]):
+            printed = io.StringIO()
+            with mock.patch(
+                f"{__name__}._time_pwsh_start", side_effect=[45.0, *warm]
+            ) as start:
+                with contextlib.redirect_stderr(printed):
+                    budget = pwsh_launch_budget.__wrapped__("pwsh")
+            self.assertEqual(start.call_count, 4, warm)
+            self.assertEqual(budget, PWSH_BUDGET_IN_STARTUPS * 0.3, warm)
+            self.assertIn(f"pwsh launch budget: {budget:.1f} s", printed.getvalue())
 
     def test_the_budget_stays_within_its_floor_and_ceiling(self) -> None:
         for warm, expected in [(0.01, PWSH_BUDGET_FLOOR), (2.0, PWSH_BUDGET_CEILING)]:
@@ -319,10 +321,12 @@ class PwshLaunchBudgetTests(InstallerHarness):
         self.assertEqual(start.call_count, 1)
         self.assertEqual(again, first)
 
-    def test_each_start_up_runs_in_a_fresh_home_under_its_deadline(self) -> None:
+    def test_each_start_up_is_timed_in_a_fresh_home_under_its_deadline(self) -> None:
         homes = []
+        clock = [100.0]
 
         def record(argv, **kwargs):
+            clock[0] += 1.5  # the start-up takes 1.5 s on the fake clock
             home = kwargs["env"]["HOME"]
             homes.append(home)
             self.assertTrue(Path(home).is_dir())
@@ -333,8 +337,9 @@ class PwshLaunchBudgetTests(InstallerHarness):
             return subprocess.CompletedProcess(argv, 0)
 
         with mock.patch(f"{__name__}.subprocess.run", side_effect=record):
-            _time_pwsh_start("pwsh")
-            _time_pwsh_start("pwsh")
+            with mock.patch.object(time, "monotonic", side_effect=lambda: clock[0]):
+                took = [_time_pwsh_start("pwsh"), _time_pwsh_start("pwsh")]
+        self.assertEqual(took, [1.5, 1.5])
         self.assertEqual(len(set(homes)), 2)
         self.assertNotIn(os.environ.get("HOME"), homes)
 

--- a/scripts/tests/test_install_memory_daemon.py
+++ b/scripts/tests/test_install_memory_daemon.py
@@ -8,12 +8,15 @@ developer's actual Codex configuration.
 
 from __future__ import annotations
 
+import contextlib
 import functools
+import io
 import json
 import os
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import textwrap
 import time
@@ -36,6 +39,11 @@ PWSH_BUDGET_IN_STARTUPS = 200
 # which run 34503494842 spent over 40 s across the launch it killed and the
 # next one.
 PWSH_COLD_START_DEADLINE = 120
+# The least and the most one launch may take, whatever the start-ups read:
+# the floor is the 30 s every launch had before the budget existed, and the
+# ceiling bounds a job with no timeout-minutes when one sample is a burst.
+PWSH_BUDGET_FLOOR = 30.0
+PWSH_BUDGET_CEILING = 180.0
 
 
 def pwsh_argv(pwsh: str, command: str) -> list[str]:
@@ -62,8 +70,8 @@ def _time_pwsh_start(pwsh: str) -> float:
 
 
 @functools.cache
-def pwsh_launch_budget(pwsh: str) -> float | None:
-    """Seconds one pwsh launch may take here, or None if pwsh never started.
+def pwsh_launch_budget(pwsh: str) -> float | str:
+    """Seconds one pwsh launch may take here, or why pwsh could not be timed.
 
     The first pwsh launch on a fresh machine pays a one-time start-up cost
     that has nothing to do with the installer. On GitHub's ubuntu-24.04
@@ -74,14 +82,31 @@ def pwsh_launch_budget(pwsh: str) -> float | None:
     once, outside every test's budget, and the budget is derived from the
     warm start-ups that follow it: a loaded machine starts pwsh slowly and
     gets a proportionally longer budget. The slowest of three is used, so one
-    lucky sample cannot shrink it.
+    lucky sample cannot shrink it, and the budget is kept between
+    PWSH_BUDGET_FLOOR and PWSH_BUDGET_CEILING and printed once. A start-up that
+    fails is cached as well, as the message every pwsh test then fails with,
+    so a broken pwsh is diagnosed once, its stderr included.
     """
     try:
         _time_pwsh_start(pwsh)  # the cold start, kept out of every budget
         warm = max(_time_pwsh_start(pwsh) for _ in range(3))
     except subprocess.TimeoutExpired:
-        return None
-    return PWSH_BUDGET_IN_STARTUPS * warm
+        return f"pwsh did not start within {PWSH_COLD_START_DEADLINE} s"
+    except subprocess.CalledProcessError as failed:
+        stderr = (failed.stderr or b"").decode(errors="replace")
+        return f"pwsh exited {failed.returncode} on start-up:\n{stderr}"
+    except OSError as unrunnable:
+        return f"pwsh could not be run: {unrunnable}"
+    budget = min(
+        max(PWSH_BUDGET_IN_STARTUPS * warm, PWSH_BUDGET_FLOOR), PWSH_BUDGET_CEILING
+    )
+    print(
+        f"pwsh launch budget: {budget:.1f} s ({PWSH_BUDGET_IN_STARTUPS}x a "
+        f"{warm:.2f} s warm start-up, kept within {PWSH_BUDGET_FLOOR:.0f}-"
+        f"{PWSH_BUDGET_CEILING:.0f} s)",
+        file=sys.stderr,
+    )
+    return budget
 
 
 class InstallerHarness(unittest.TestCase):
@@ -196,8 +221,8 @@ class InstallerHarness(unittest.TestCase):
         if pwsh is None:
             self.skipTest("pwsh is not installed")
         budget = pwsh_launch_budget(pwsh)
-        if budget is None:
-            self.fail(f"pwsh did not start within {PWSH_COLD_START_DEADLINE} s")
+        if isinstance(budget, str):
+            self.fail(budget)
         try:
             return subprocess.run(
                 pwsh_argv(pwsh, command),
@@ -211,10 +236,7 @@ class InstallerHarness(unittest.TestCase):
             )
         except subprocess.TimeoutExpired as hung:
             output = (hung.output or b"").decode(errors="replace")
-            self.fail(
-                f"pwsh ran past its {budget:.1f} s budget "
-                f"({PWSH_BUDGET_IN_STARTUPS}x its start-up here):\n{output}"
-            )
+            self.fail(f"pwsh ran past its {hung.timeout:.1f} s budget:\n{output}")
 
     def invocation_log(self) -> list[str]:
         if not self.log.exists():
@@ -228,16 +250,48 @@ class PwshLaunchBudgetTests(InstallerHarness):
             with self.assertRaisesRegex(AssertionError, r"past its 2\.0 s budget"):
                 self.run_pwsh("Start-Sleep -Seconds 60", self.environment())
 
-    def test_a_pwsh_that_never_started_fails_the_launch(self) -> None:
-        with mock.patch(f"{__name__}.pwsh_launch_budget", return_value=None):
+    def test_a_pwsh_that_could_not_be_timed_fails_the_launch(self) -> None:
+        reason = f"pwsh did not start within {PWSH_COLD_START_DEADLINE} s"
+        with mock.patch(f"{__name__}.pwsh_launch_budget", return_value=reason):
             with self.assertRaisesRegex(AssertionError, "did not start within"):
                 self.run_pwsh("exit 0", self.environment())
 
     def test_the_cold_start_is_kept_out_of_the_budget(self) -> None:
-        starts = [45.0, 0.3, 0.2, 0.25]  # cold, then three warm
-        with mock.patch(f"{__name__}._time_pwsh_start", side_effect=starts):
-            budget = pwsh_launch_budget.__wrapped__("pwsh")
+        starts = [45.0, 0.2, 0.25, 0.3]  # cold, then three warm, slowest last
+        printed = io.StringIO()
+        with mock.patch(f"{__name__}._time_pwsh_start", side_effect=starts) as start:
+            with contextlib.redirect_stderr(printed):
+                budget = pwsh_launch_budget.__wrapped__("pwsh")
+        self.assertEqual(start.call_count, 4)
         self.assertEqual(budget, PWSH_BUDGET_IN_STARTUPS * 0.3)
+        self.assertIn(f"pwsh launch budget: {budget:.1f} s", printed.getvalue())
+
+    def test_the_budget_stays_within_its_floor_and_ceiling(self) -> None:
+        for warm, expected in [(0.01, PWSH_BUDGET_FLOOR), (2.0, PWSH_BUDGET_CEILING)]:
+            with mock.patch(
+                f"{__name__}._time_pwsh_start", side_effect=[1.0, warm, warm, warm]
+            ):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    self.assertEqual(pwsh_launch_budget.__wrapped__("pwsh"), expected)
+
+    def test_a_start_up_that_fails_is_reported_with_its_cause(self) -> None:
+        for failure, message in [
+            (subprocess.TimeoutExpired("pwsh", PWSH_COLD_START_DEADLINE), "did not start within 120 s"),
+            (subprocess.CalledProcessError(1, "pwsh", stderr=b"no libicu"), "exited 1 on start-up:\nno libicu"),
+            (FileNotFoundError(2, "No such file"), "could not be run"),
+        ]:
+            with mock.patch(f"{__name__}._time_pwsh_start", side_effect=failure):
+                self.assertIn(message, pwsh_launch_budget.__wrapped__("pwsh"))
+
+    def test_a_failed_start_up_is_timed_only_once(self) -> None:
+        unrunnable = "/nonexistent/pwsh-that-fails-once"
+        with mock.patch(
+            f"{__name__}._time_pwsh_start", side_effect=OSError("gone")
+        ) as start:
+            first = pwsh_launch_budget(unrunnable)
+            again = pwsh_launch_budget(unrunnable)
+        self.assertEqual(start.call_count, 1)
+        self.assertEqual(again, first)
 
 
 class ShellCodexWiringTests(InstallerHarness):


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`test/pwsh-installer-cold-start` → `develop`.

## Description

`test_powershell_installer_refuses_disabled_tls_verification` raised `TimeoutExpired` after 30 s in the guard-contract job of [run 34503494842](https://github.com/cyberlife-coder/VelesDB/actions/runs/34503494842/job/102960207040), while the other 853 tests passed. The cause is neither a regression nor the installer. It is the job's first pwsh launch.

**Where the time goes.** Per-test durations of every pwsh test in `test_install_memory_daemon.py`, read off the job-log timestamps (a line's stamp marks the end of that test):

| run | 1st pwsh test | 2nd | 3rd–9th |
|---|---|---|---|
| 34503494842 (red) | >30.18 s, killed | 12.34 s | 1.08–1.62 s |
| 34454534171 | 8.54 s | 1.27 s | 1.22–1.79 s |
| 34471937061 | 19.86 s | 0.83 s | 0.79–1.24 s |
| 34473046764 | 6.46 s | 0.94 s | 0.92–1.42 s |
| 34523322387 | 2.85 s | 1.27 s | 1.23–1.77 s |
| 34529825042 | 8.86 s | 0.98 s | 0.95–1.50 s |
| 34530764716 | 16.00 s | 0.94 s | 0.84–1.27 s |

Every launch runs the same installer in an equally fresh `HOME`, and every launch after the first costs about 1 s. So the variable cost is a one-time start-up cost of the runner (ubuntu-24.04, pwsh 7.6.5), not work the installer does. Whichever test launched pwsh first paid it inside its own fixed 30 s.

**What it is not.** Each of these was checked, not assumed:
- **Avoidable installer work under `-WireOnly`.** The only lookups of an absent command are the two `Get-Command curl.exe` calls. `Trace-Command -Name CommandDiscovery` shows a PATH walk and the `get-` retry, with no module auto-load. With 300 extra modules on `PSModulePath` the lookup costs +0.07 s either way, with or without `-CommandType Application`, so that change would buy nothing.
- **A prompt waiting on stdin.** With stdin held open and never written, the run returns in 0.86 s and refuses as it should. `Read-Host` is only reachable outside `-WireOnly`.
- **A network call.** The `-WireOnly` health probes need `curl.exe` and a CA file, and the test provides neither. Opting out of pwsh's own telemetry changes start-up by 0.02 s, and the update check writes nothing under `-NonInteractive`.
- **The fresh `HOME`.** It only costs pwsh its start-up JIT profile: a 0.26 s median start-up instead of 0.20 s.

**The fix.** Test-only; the installer is untouched.
- **Cold start paid once.** `pwsh_launch_budget()` pays the cold start once per process. It discards one start, then times the slowest of three warm start-ups, each in a fresh `HOME` like the tests use. Each launch is budgeted at 200 times the slowest of them. The budget is kept within 30–180 s and printed once in the job's log.
- **One helper for every test launch.** Every test's pwsh launch now goes through `run_pwsh`; six call sites each held their own `subprocess.run(..., timeout=30)`. The calibration's own start-ups share its command line (`pwsh_argv`), under a deadline of their own. A launch that runs past its budget fails with the timeout that fired and the output so far, instead of a bare `TimeoutExpired`.
- **Why 200.** Steady launches cost 2–4 start-ups and busy ones up to 12. On a loaded machine, though, one launch ran past 50 start-ups timed seconds earlier. A first version at 50 failed 1 local run in 20 (a 12.7 s budget) that the old 30 s would have passed, so the measurements ruled 50 out. At 200, the budget comes to about 46 s on the measuring machine, and a slower machine gets proportionally more.
- **Eight tests hold the mechanism.**
  - A hung launch fails at the timeout it was given, and the failure prints that timeout.
  - Its output so far is in the failure.
  - A pwsh that could not be timed fails with the reason.
  - The cold sample never enters the budget, exactly four start-ups are timed, and the slowest warm one sets it, wherever it falls among the three.
  - The budget stays within its floor and its ceiling.
  - A start-up that times out, exits non-zero or cannot run is reported with its cause, its stderr and the timeout that fired.
  - A failed start-up is timed only once.
  - Each start-up is timed around its run, in a fresh `HOME`, under its deadline, with its output captured and a non-zero exit raised.

  Each of the 21 mutations of the mechanism turns at least one of them red, each of the eight goes red under at least one, and the unmutated file stays green (see the review follow-ups below).

Every installer test asserts exactly what it asserted before.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue): a flaky gate test. No product code changes.

## How Has This Been Tested?

**The CI failure, reproduced deterministically.** A `pwsh` wrapper placed first on `PATH` sleeps 35 s on its first start only:
- On `origin/develop`, the test fails with `TimeoutExpired` at 30.0 s, the same failure as run 34503494842.
- On this branch, it passes in 36.9 s. The calibration absorbs the cold start, and the launch itself is warm.

**Timing.** 20 runs of `test_powershell_installer_refuses_disabled_tls_verification` per side. Old and new alternate within the same rounds, so neither side gets the quieter moments. Measured on macOS with pwsh 7.6.4, 18 CPUs shared with an unrelated build, load average 4.7–7.4:

| | passed | installer launch, min / med / p90 / max | test wall, median |
|---|---|---|---|
| before (`origin/develop`) | 20/20 | 0.77 / 0.78 / 0.79 / 0.82 s under a 30 s timeout | 0.78 s |
| after | 20/20 | 0.77 / 0.78 / 0.80 / 0.86 s under a 46–48 s budget | 1.71 s (+0.93 s calibration, once per process) |

Suites:
- `python3 -m unittest scripts.tests.test_install_memory_daemon`: 25 tests, OK (17 before, plus the 8 above).
- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .`: 882 tests, OK, at da35152e.
- `JOBS=hygiene bash scripts/local-ci.sh`: spelling (`typos`) passes. `taplo` and `cargo-machete` are not installed on the machine that ran it, so only CI checks them; this change touches no manifest.
- `check-feature-claims.py`, `check-perf-claims.py --no-criterion`, `check-promise-contract.py`: passed.
- `python3 scripts/check-ai-attribution.py origin/develop..HEAD`: passed.

**On the runner.** The first pwsh test in this PR's guard-contract job now also carries the calibration (the cold start plus three warm starts). What should hold there is that no pwsh launch runs against a fixed 30 s anymore, and every later pwsh test stays around 1 s.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- **The local DRY hook was skipped for this PR, deliberately.** The hook runs jscpd over the whole of every file a branch touches, and this file carries parallel Shell/PowerShell test bodies that predate this change. With the hook's settings (at least 10 lines and 50 tokens per block), `develop`'s file has 9 clones and 128 duplicated lines (21.1 %). This branch has 6 and 80: 12.5 % at e2ac1985, and 10.75 % at da35152e, whose file the follow-ups lengthened with no new clone. The six copies of `subprocess.run(..., timeout=30)` are gone, and every clone that remains is a pair that already exists on `develop`. The commit and this PR were therefore created with the local DRY hook bypassed. Folding the twin Shell/PowerShell tests into shared bodies is left to a separate change, so this one stays a flake fix.

- An earlier pair of 20-run series, taken one after the other rather than interleaved, gave 0.87 / 1.11 / 1.57 / 2.54 s for the old test. That was measured under heavier load and is not comparable, which is why the final comparison is interleaved.
- Left as is, out of scope: the test environment does not set `POWERSHELL_TELEMETRY_OPTOUT`, so each pwsh launch sends pwsh's start-up telemetry. It has no measurable effect on timing.

## Review follow-up (e407eb90)

An adversarial review of e2ac1985 found five gaps, all fixed in e407eb90:
- The hung-launch test stayed green with the old fixed 30 s timeout, because the failure printed the configured budget. It now prints the timeout that fired.
- The warm samples put the slowest first. They now put it last, and the test counts four start-ups.
- A start-up that timed out, exited non-zero or could not run was either untested or never cached. As a result, a broken pwsh re-ran in every test with its stderr hidden. Each case is now cached as the message every pwsh test fails with, stderr included, and each is tested.
- The budget had no bound. It is now kept within 30–180 s and printed once. Locally it read `pwsh launch budget: 53.3 s (200x a 0.27 s warm start-up, kept within 30-180 s)`.
- This body named the DRY hook's bypass variable, and gave the wrong base for the rebase.

Proof:
- Each of the 10 mutations of the new code turns a named test red.
- `test_install_memory_daemon` runs 23 tests, OK.
- `unittest discover -s scripts/tests` runs 880 tests, OK.
- jscpd, run with the DRY hook's settings, finds 6 clones and 80 duplicated lines in the file, as on e2ac1985. That is 11.5 % of the now longer file, and no clone touches the new code.

## Second review follow-up (b503623f)

A review of e407eb90 found six more gaps, all fixed in b503623f:
- The slowest warm start-up came last, so a budget taken from the last sample passed. It now sits in the middle, and a budget taken from the first or the last sample fails.
- No test looked at what a start-up passes to `subprocess.run`. Its deadline, `check`, captured output and fresh `HOME` could each go while the suite stayed green. One test now asserts them.
- A start-up that timed out lost its stderr, and named the configured deadline instead of the one that fired. It keeps both now, through one helper shared with a non-zero exit.
- A hung launch's output so far was kept, but no test saw it. One does now, on a mocked launch: a real pwsh's first start-up can outlast any budget short enough to test, and would print nothing.
- A comment gave the start-up deadline to one launch where it covers all four. This body called the budget "200 of those start-ups" and every launch, calibration included, `run_pwsh`'s.
- Two lines ran past the file's 88 columns.

Proof:
- Each of the 19 mutations turns a named test red, and each of the eight tests goes red under at least one of them.
- `test_install_memory_daemon` runs 25 tests, OK.
- `unittest discover -s scripts/tests` runs 882 tests, OK.

## Third review follow-up (da35152e)

A review of b503623f found two more gaps and a stale line, all fixed in da35152e:
- One ordering of the warm samples rules out only two of their three positions: a budget read from the middle sample still passed. The test now puts the slowest sample in each of the three positions in turn.
- No test looked at the timing itself: a start-up timed after its run read 0 s, and the budget sat at its floor unnoticed. The fresh-`HOME` test now runs on a fake clock that each start-up advances, and asserts what it measured.
- The "Suites" list above still gave e2ac1985's suite count. It now gives this head's.

Proof:
- Each of the 21 mutations turns a named test red, and each of the eight tests goes red under at least one of them.
- `test_install_memory_daemon` runs 25 tests, OK, and `unittest discover -s scripts/tests` runs 882 tests, OK.
